### PR TITLE
/src/ngx_stream_lua_module.c(446) : error C2039: 'requires_log' : is …

### DIFF
--- a/src/ngx_stream_lua_common.h
+++ b/src/ngx_stream_lua_common.h
@@ -143,6 +143,7 @@ struct ngx_stream_lua_main_conf_s {
 
     unsigned                             requires_access:1;
     unsigned                             requires_shm:1;
+    unsigned                             requires_log:1;
 };
 
 


### PR DESCRIPTION
…not a member of 'ngx_stream_lua_main_conf_s'

/src/ngx_stream_lua_module.c(446) : error C2039: 'requires_log' : is not a member of 'ngx_stream_lua_main_conf_s'

Loads more errors from other modules, such as /src/ngx_stream_lua_util.c(1465) : error C203
9: 'header_sent' : is not a member of 'ngx_stream_session_s'
        src/stream\ngx_stream.h(139) : see declaration of 'ngx_stream_session_s'

\nginx\src\stream/ngx_stream.h
    line 151:
        ngx_stream_upstream_t  *upstream;
    +    unsigned                header_sent:1;  /* lua_stream */
    };

Working on getting a complete report, too many errors to fix with one pull ;-)