### PR TITLE
ngx.socket.tcp receive bsd style

### DIFF
--- a/src/ngx_stream_lua_socket_tcp.c
+++ b/src/ngx_stream_lua_socket_tcp.c
@@ -1995,6 +1995,7 @@ ngx_stream_lua_socket_read_line(void *data, ssize_t bytes)
     return NGX_AGAIN;
 }
 
+
 static ngx_int_t
 ngx_stream_lua_socket_read_bsd(void *data, ssize_t bytes)
 {

--- a/src/ngx_stream_lua_socket_tcp.c
+++ b/src/ngx_stream_lua_socket_tcp.c
@@ -2001,7 +2001,6 @@ ngx_stream_lua_socket_read_bsd(void *data, ssize_t bytes)
     ngx_stream_lua_socket_tcp_upstream_t      *u = data;
 
     ngx_buf_t                   *b;
-    u_char                       c;
 
     ngx_log_debug0(NGX_LOG_DEBUG_STREAM, u->request->connection->log, 0,
                    "stream lua tcp socket read bsd");

--- a/src/ngx_stream_lua_socket_tcp.c
+++ b/src/ngx_stream_lua_socket_tcp.c
@@ -2002,8 +2002,10 @@ ngx_stream_lua_socket_read_bsd(void *data, ssize_t bytes)
 
     ngx_buf_t                   *b;
 
+#if (NGX_DEBUG)
     ngx_log_debug0(NGX_LOG_DEBUG_STREAM, u->request->connection->log, 0,
                    "stream lua tcp socket read bsd");
+#endif
 
     if (bytes == 0) {
         u->ft_type |= NGX_STREAM_LUA_SOCKET_FT_CLOSED;

--- a/src/ngx_stream_lua_socket_tcp.c
+++ b/src/ngx_stream_lua_socket_tcp.c
@@ -88,6 +88,7 @@ static int ngx_stream_lua_socket_write_error_retval_handler(
     ngx_stream_session_t *s, ngx_stream_lua_socket_tcp_upstream_t *u,
     lua_State *L);
 static ngx_int_t ngx_stream_lua_socket_read_all(void *data, ssize_t bytes);
+static ngx_int_t ngx_stream_lua_socket_read_bsd(void *data, ssize_t bytes);
 static ngx_int_t ngx_stream_lua_socket_read_until(void *data, ssize_t bytes);
 static ngx_int_t ngx_stream_lua_socket_read_chunk(void *data, ssize_t bytes);
 static int ngx_stream_lua_socket_tcp_receiveuntil(lua_State *L);
@@ -1736,6 +1737,10 @@ ngx_stream_lua_socket_tcp_receive(lua_State *L)
                 u->input_filter = ngx_stream_lua_socket_read_all;
                 break;
 
+            case 'b':
+                u->input_filter = ngx_stream_lua_socket_read_bsd;
+                break;
+
             default:
                 return luaL_argerror(L, 2, "bad pattern argument");
                 break;
@@ -1988,6 +1993,36 @@ ngx_stream_lua_socket_read_line(void *data, ssize_t bytes)
     u->buf_in->buf->last = dst;
 
     return NGX_AGAIN;
+}
+
+static ngx_int_t
+ngx_stream_lua_socket_read_bsd(void *data, ssize_t bytes)
+{
+    ngx_stream_lua_socket_tcp_upstream_t      *u = data;
+
+    ngx_buf_t                   *b;
+    u_char                       c;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, u->request->connection->log, 0,
+                   "stream lua tcp socket read bsd");
+
+    if (bytes == 0) {
+        u->ft_type |= NGX_STREAM_LUA_SOCKET_FT_CLOSED;
+        return NGX_ERROR;
+    }
+
+    b = &u->buffer;
+
+    dd("already read: %p: %.*s", u->buf_in,
+       (int) (u->buf_in->buf->last - u->buf_in->buf->pos),
+       u->buf_in->buf->pos);
+
+    dd("data read: %.*s", (int) bytes, b->pos);
+
+    u->buf_in->buf->last = ngx_cpymem(u->buf_in->buf->last, b->pos, bytes);
+    b->pos += bytes;
+
+    return NGX_OK;
 }
 
 

--- a/t/137-tcp-socket-receive-bsd-style.t
+++ b/t/137-tcp-socket-receive-bsd-style.t
@@ -1,0 +1,72 @@
+
+use Test::Nginx::Socket::Lua::Stream 'no_plan';
+
+repeat_each(10);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: *b pattern for receive
+--- config
+    location = /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            sock:settimeout(100)
+            assert(sock:connect("127.0.0.1", 5678))
+            sock:send("10")
+            ngx.sleep(0.01)
+            sock:send("2")
+            ngx.sleep(0.01)
+            sock:send("4")
+
+            local pow, _ = sock:receive('*l')
+            sock:close()
+            ngx.say(pow)
+        }
+    }
+--- main_config
+    stream {
+        server {
+            listen 5678;
+            content_by_lua_block {
+                local function is_power_of_two(str)
+                    local num = tonumber(str)
+                    if num <= 0 then
+                        return false, nil 
+                    end 
+                    local power = 0 
+                    while num ~= 1 do
+                        if math.fmod(num, 2) ~= 0 then
+                            return false, nil 
+                        end 
+                        num = num / 2 
+                        power = power + 1 
+                    end 
+                    return true, power
+                end
+
+                local sock = ngx.req.socket(true)
+                local msg = ''
+                local pow
+                while true do
+                    local chunk, err = sock:receive('*b')
+                    if not chunk then
+                        break
+                    end
+                    msg = msg .. chunk
+                    local ok, num = is_power_of_two(msg)
+                    if ok then
+                        pow = num
+                        break
+                    end
+                end
+                sock:send(tostring(pow) .. '\n')
+            }
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+10

--- a/t/137-tcp-socket-receive-bsd-style.t
+++ b/t/137-tcp-socket-receive-bsd-style.t
@@ -70,3 +70,7 @@ __DATA__
 GET /t
 --- response_body
 10
+--- no_error_log
+[error]
+--- error_log
+stream lua tcp socket read bsd


### PR DESCRIPTION
Implement bsd style receive('*b') for ngx.socket.tcp, and add a simple test case in file t/137-tcp-socket-receive-bsd-style.t

春哥好，今天看到openresty邮件列表里面有关于BSD风格的receive的讨论，我印象中关于这个主题在邮件列表里面已经多次出现了。因此一时兴起写了实现了这个接口，并附上一个简单的测试文件(对Test::Nginx的语法还不完全了解，所以只写一个最简单的test case)。目前还没有去在openresty的文档中添加使用方法，如果这个PR被接受，我再去补充文档，到时候再提交一个PR。英文学得不好，表达不够native，因此前面仅用一段简单的英语做描述，不知道是否符合规范？希望能得到春哥的指点，谢谢。
