### PR TITLE
cross modules stream/http shared dict

### DIFF
--- a/src/ngx_stream_lua_shdict.h
+++ b/src/ngx_stream_lua_shdict.h
@@ -44,8 +44,8 @@ typedef struct {
 ngx_int_t ngx_stream_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data);
 void ngx_stream_lua_shdict_rbtree_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
-void ngx_stream_lua_inject_shdict_api(ngx_stream_lua_main_conf_t *lmcf,
-    lua_State *L);
+void ngx_stream_lua_inject_shdict_api(ngx_log_t *log,
+    ngx_stream_lua_main_conf_t *lmcf, lua_State *L);
 
 
 #endif /* _NGX_STREAM_LUA_SHDICT_H_INCLUDED_ */

--- a/src/ngx_stream_lua_util.c
+++ b/src/ngx_stream_lua_util.c
@@ -2674,7 +2674,7 @@ ngx_stream_lua_inject_ngx_api(lua_State *L, ngx_stream_lua_main_conf_t *lmcf,
 
     ngx_stream_lua_inject_req_api(log, L);
     ngx_stream_lua_inject_variable_api(L);
-    ngx_stream_lua_inject_shdict_api(lmcf, L);
+    ngx_stream_lua_inject_shdict_api(log, lmcf, L);
     ngx_stream_lua_inject_socket_tcp_api(log, L);
     ngx_stream_lua_inject_socket_udp_api(log, L);
     ngx_stream_lua_inject_uthread_api(log, L);


### PR DESCRIPTION
This addresses issue openresty/stream-lua-nginx-module#25 - cross modules shared dict.
Tested (including adding/removing dicts and reload) but tests still need to be added.

I'v covered different ways to do this. Most were either over complicated or/and risky.
This one is quite simple - a module references the other module zones only during post-configuration phase.  It works as it relies on the fact (to my best knowledge) that across all pushed dict functions, `zone->data` is `ngx_stream_lua_shdict_ctx_t` or `ngx_http_lua_shdict_ctx_t` which are cast-interchangeable (they are aligned in the attributes that they are referenced to).
The single non compatible attribute is `ctx->main_conf` but it's only accessed during configuration phase where each module takes care of it's own.
Another big advantage is that it works without any changes to `lua_ngx_module`. Until http module adopts the change, a dict should be configured in http context for this to work.  
This is of course not ideal but it's by far the simplest way. 
If possible, it would be best to make these structs fully aligned or even better including a common header file for this. Another TODO is "selectively sharing dicts".

test configuration attached
[nginx.txt](https://github.com/openresty/stream-lua-nginx-module/files/459787/nginx.txt)
