### PR TITLE
feature: balancer_by_lua_* for stream subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ documentation of `ngx_http_lua_module` for more details about their usage and be
 * [init_worker_by_lua_file](https://github.com/openresty/lua-nginx-module#init_worker_by_lua_file)
 * [content_by_lua_block](https://github.com/openresty/lua-nginx-module#content_by_lua_block)
 * [content_by_lua_file](https://github.com/openresty/lua-nginx-module#content_by_lua_file)
+* [balancer_by_lua_block](https://github.com/openresty/lua-nginx-module#balancer_by_lua_block)
+* [balancer_by_lua_file](https://github.com/openresty/lua-nginx-module#balancer_by_lua_file)
 * [lua_shared_dict](https://github.com/openresty/lua-nginx-module#lua_shared_dict)
 * [lua_socket_connect_timeout](https://github.com/openresty/lua-nginx-module#lua_socket_connect_timeout)
 * [lua_socket_buffer_size](https://github.com/openresty/lua-nginx-module#lua_socket_buffer_size)
@@ -254,6 +256,9 @@ output to be completely flushed out (to the system socket send buffers).
 * [ngx.worker.pid](https://github.com/openresty/lua-nginx-module#ngxworkerpid)
 * [ngx.worker.count](https://github.com/openresty/lua-nginx-module#ngxworkercount)
 * [ngx.worker.id](https://github.com/openresty/lua-nginx-module#ngxworkerid)
+* [ngx.balancer](https://github.com/openresty/lua-nginx-module#ngxbalancer)
+
+    For now, only `set_current_peer` and `set_more_tries`(Not respect `proxy_next_upstream_tries`) provided.
 * [coroutine.create](https://github.com/openresty/lua-nginx-module#coroutinecreate)
 * [coroutine.resume](https://github.com/openresty/lua-nginx-module#coroutineresume)
 * [coroutine.yield](https://github.com/openresty/lua-nginx-module#coroutineyield)
@@ -268,7 +273,7 @@ TODO
 
 * Add new directives `access_by_lua_block` and `access_by_lua_file`.
 * Add new directives `log_by_lua_block` and `log_by_lua_file`.
-* Add new directives `balancer_by_lua_block` and `balancer_by_lua_file`.
+* Add `set_timeouts` in `ngx.balancer` and respect `proxy_next_upstream_tries` for `set_more_tries`.
 * Add new directives `ssl_certificate_by_lua_block` and `ssl_certificate_by_lua_file`.
 * Add `ngx.semaphore` API.
 * Add `ngx_meta_lua_module` to share as much code as possible between this module and `ngx_http_lua_module` and allow sharing

--- a/config
+++ b/config
@@ -306,6 +306,7 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
                 $ngx_addon_dir/src/ngx_stream_lua_directive.c \
                 $ngx_addon_dir/src/ngx_stream_lua_lex.c \
                 $ngx_addon_dir/src/ngx_stream_lua_contentby.c \
+                $ngx_addon_dir/src/ngx_stream_lua_balancer.c \
                 $ngx_addon_dir/src/ngx_stream_lua_util.c \
                 $ngx_addon_dir/src/ngx_stream_lua_cache.c \
                 $ngx_addon_dir/src/ngx_stream_lua_clfactory.c \
@@ -343,6 +344,7 @@ NGX_ADDON_DEPS="$NGX_ADDON_DEPS \
                 $ngx_addon_dir/src/ngx_stream_lua_common.h \
                 $ngx_addon_dir/src/ngx_stream_lua_lex.h \
                 $ngx_addon_dir/src/ngx_stream_lua_contentby.h \
+                $ngx_addon_dir/src/ngx_stream_lua_balancer.h \
                 $ngx_addon_dir/src/ngx_stream_lua_util.h \
                 $ngx_addon_dir/src/ngx_stream_lua_cache.h \
                 $ngx_addon_dir/src/ngx_stream_lua_clfactory.h \

--- a/src/api/ngx_stream_lua_api.h
+++ b/src/api/ngx_stream_lua_api.h
@@ -19,7 +19,7 @@
 /* Public API for other Nginx modules */
 
 
-#define ngx_stream_lua_version  10001
+#define ngx_stream_lua_version  10006
 
 
 typedef struct {

--- a/src/ngx_stream_lua_balancer.c
+++ b/src/ngx_stream_lua_balancer.c
@@ -168,7 +168,9 @@ ngx_stream_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 
         lscf->balancer.src_key = p;
 
-        p = ngx_copy(p, NGX_STREAM_LUA_INLINE_TAG, NGX_STREAM_LUA_INLINE_TAG_LEN);
+        p = ngx_copy(p, NGX_STREAM_LUA_INLINE_TAG,
+                     NGX_STREAM_LUA_INLINE_TAG_LEN);
+
         p = ngx_stream_lua_digest_hex(p, value[1].data, value[1].len);
         *p = '\0';
     }
@@ -215,7 +217,9 @@ ngx_stream_lua_balancer_init_peer(ngx_stream_session_t *s,
     ngx_stream_lua_srv_conf_t            *bcf;
     ngx_stream_lua_balancer_peer_data_t  *bp;
 
-    bp = ngx_pcalloc(s->connection->pool, sizeof(ngx_stream_lua_balancer_peer_data_t));
+    bp = ngx_pcalloc(s->connection->pool,
+                     sizeof(ngx_stream_lua_balancer_peer_data_t));
+
     if (bp == NULL) {
         return NGX_ERROR;
     }
@@ -410,7 +414,7 @@ int
 ngx_stream_lua_ffi_balancer_set_current_peer(ngx_stream_session_t *s,
     const u_char *addr, size_t addr_len, int port, char **err)
 {
-    ngx_url_t              url;
+    ngx_url_t                url;
     ngx_stream_lua_ctx_t    *ctx;
     ngx_stream_upstream_t   *u;
 

--- a/src/ngx_stream_lua_balancer.c
+++ b/src/ngx_stream_lua_balancer.c
@@ -1,0 +1,543 @@
+
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+
+#include "ngx_stream_lua_cache.h"
+#include "ngx_stream_lua_balancer.h"
+#include "ngx_stream_lua_util.h"
+#include "ngx_stream_lua_directive.h"
+
+
+struct ngx_stream_lua_balancer_peer_data_s {
+    /* the round robin data must be first */
+    ngx_stream_upstream_rr_peer_data_t   rrp;
+
+    ngx_stream_lua_srv_conf_t           *conf;
+    ngx_stream_session_t                *session;
+
+    ngx_uint_t                           more_tries;
+    ngx_uint_t                           total_tries;
+
+    struct sockaddr                     *sockaddr;
+    socklen_t                            socklen;
+
+    ngx_str_t                           *host;
+    in_port_t                            port;
+};
+
+
+static ngx_int_t ngx_stream_lua_balancer_init(ngx_conf_t *cf,
+    ngx_stream_upstream_srv_conf_t *us);
+static ngx_int_t ngx_stream_lua_balancer_init_peer(ngx_stream_session_t *s,
+    ngx_stream_upstream_srv_conf_t *us);
+static ngx_int_t ngx_stream_lua_balancer_get_peer(ngx_peer_connection_t *pc,
+    void *data);
+static ngx_int_t ngx_stream_lua_balancer_by_chunk(lua_State *L,
+    ngx_stream_session_t *s);
+void ngx_stream_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+    ngx_uint_t state);
+
+
+ngx_int_t
+ngx_stream_lua_balancer_handler_file(ngx_stream_session_t *s,
+    ngx_stream_lua_srv_conf_t *lscf, lua_State *L)
+{
+    ngx_int_t           rc;
+
+    rc = ngx_stream_lua_cache_loadfile(s->connection->log, L,
+                                       lscf->balancer.src.data,
+                                       lscf->balancer.src_key);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    /*  make sure we have a valid code chunk */
+    ngx_stream_lua_assert(lua_isfunction(L, -1));
+
+    return ngx_stream_lua_balancer_by_chunk(L, s);
+}
+
+
+ngx_int_t
+ngx_stream_lua_balancer_handler_inline(ngx_stream_session_t *s,
+    ngx_stream_lua_srv_conf_t *lscf, lua_State *L)
+{
+    ngx_int_t           rc;
+
+    rc = ngx_stream_lua_cache_loadbuffer(s->connection->log, L,
+                                         lscf->balancer.src.data,
+                                         lscf->balancer.src.len,
+                                         lscf->balancer.src_key,
+                                         "=balancer_by_lua");
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    /*  make sure we have a valid code chunk */
+    ngx_stream_lua_assert(lua_isfunction(L, -1));
+
+    return ngx_stream_lua_balancer_by_chunk(L, s);
+}
+
+
+char *
+ngx_stream_lua_balancer_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    char        *rv;
+    ngx_conf_t   save;
+
+    save = *cf;
+    cf->handler = ngx_stream_lua_balancer_by_lua;
+    cf->handler_conf = conf;
+
+    rv = ngx_stream_lua_conf_lua_block_parse(cf, cmd);
+
+    *cf = save;
+
+    return rv;
+}
+
+
+char *
+ngx_stream_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    u_char                      *p;
+    u_char                      *name;
+    ngx_str_t                   *value;
+    ngx_stream_lua_srv_conf_t   *lscf = conf;
+
+    ngx_stream_upstream_srv_conf_t  *uscf;
+
+    dd("enter");
+
+    /*  must specify a content handler */
+    if (cmd->post == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (lscf->balancer.handler) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    lscf->balancer.handler = (ngx_stream_lua_srv_conf_handler_pt) cmd->post;
+
+    if (cmd->post == ngx_stream_lua_balancer_handler_file) {
+        /* Lua code in an external file */
+
+        name = ngx_stream_lua_rebase_path(cf->pool, value[1].data,
+                                          value[1].len);
+        if (name == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        lscf->balancer.src.data = name;
+        lscf->balancer.src.len = ngx_strlen(name);
+
+        p = ngx_palloc(cf->pool, NGX_STREAM_LUA_FILE_KEY_LEN + 1);
+        if (p == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        lscf->balancer.src_key = p;
+
+        p = ngx_copy(p, NGX_STREAM_LUA_FILE_TAG, NGX_STREAM_LUA_FILE_TAG_LEN);
+        p = ngx_stream_lua_digest_hex(p, value[1].data, value[1].len);
+        *p = '\0';
+
+    } else {
+        /* inlined Lua code */
+
+        lscf->balancer.src = value[1];
+
+        p = ngx_palloc(cf->pool, NGX_STREAM_LUA_INLINE_KEY_LEN + 1);
+        if (p == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        lscf->balancer.src_key = p;
+
+        p = ngx_copy(p, NGX_STREAM_LUA_INLINE_TAG, NGX_STREAM_LUA_INLINE_TAG_LEN);
+        p = ngx_stream_lua_digest_hex(p, value[1].data, value[1].len);
+        *p = '\0';
+    }
+
+    uscf = ngx_stream_conf_get_module_srv_conf(cf, ngx_stream_upstream_module);
+
+    if (uscf->peer.init_upstream) {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "load balancing method redefined");
+    }
+
+    uscf->peer.init_upstream = ngx_stream_lua_balancer_init;
+
+    /* todo */
+    uscf->flags = NGX_STREAM_UPSTREAM_CREATE
+                  |NGX_STREAM_UPSTREAM_WEIGHT
+                  |NGX_STREAM_UPSTREAM_MAX_FAILS
+                  |NGX_STREAM_UPSTREAM_FAIL_TIMEOUT
+                  |NGX_STREAM_UPSTREAM_DOWN;
+
+    return NGX_CONF_OK;
+}
+
+
+static ngx_int_t
+ngx_stream_lua_balancer_init(ngx_conf_t *cf,
+    ngx_stream_upstream_srv_conf_t *us)
+{
+    if (ngx_stream_upstream_init_round_robin(cf, us) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    /* this callback is called upon individual sessions */
+    us->peer.init = ngx_stream_lua_balancer_init_peer;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_stream_lua_balancer_init_peer(ngx_stream_session_t *s,
+    ngx_stream_upstream_srv_conf_t *us)
+{
+    ngx_stream_lua_srv_conf_t            *bcf;
+    ngx_stream_lua_balancer_peer_data_t  *bp;
+
+    bp = ngx_pcalloc(s->connection->pool, sizeof(ngx_stream_lua_balancer_peer_data_t));
+    if (bp == NULL) {
+        return NGX_ERROR;
+    }
+
+    s->upstream->peer.data = &bp->rrp;
+
+    if (ngx_stream_upstream_init_round_robin_peer(s, us) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    s->upstream->peer.get = ngx_stream_lua_balancer_get_peer;
+    s->upstream->peer.free = ngx_stream_lua_balancer_free_peer;
+
+    bcf = ngx_stream_conf_upstream_srv_conf(us, ngx_stream_lua_module);
+
+    bp->conf = bcf;
+    bp->session = s;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_stream_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+{
+    lua_State                            *L;
+    ngx_int_t                             rc;
+    ngx_stream_session_t                 *s;
+    ngx_stream_lua_ctx_t                 *ctx;
+    ngx_stream_lua_srv_conf_t            *lscf;
+    ngx_stream_lua_main_conf_t           *lmcf;
+    ngx_stream_lua_balancer_peer_data_t  *bp = data;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, pc->log, 0,
+                   "lua balancer peer, tries: %ui", pc->tries);
+
+    lscf = bp->conf;
+
+    s = bp->session;
+
+    ngx_stream_lua_assert(lscf->balancer.handler && s);
+
+    ctx = ngx_stream_get_module_ctx(s, ngx_stream_lua_module);
+
+    if (ctx == NULL) {
+        ctx = ngx_stream_lua_create_ctx(s);
+        if (ctx == NULL) {
+            return NGX_ERROR;
+        }
+
+        L = ngx_stream_lua_get_lua_vm(s, ctx);
+
+    } else {
+        L = ngx_stream_lua_get_lua_vm(s, ctx);
+
+        dd("reset ctx");
+        ngx_stream_lua_reset_ctx(s, L, ctx);
+    }
+
+    ctx->context = NGX_STREAM_LUA_CONTEXT_BALANCER;
+
+    bp->sockaddr = NULL;
+    bp->socklen = 0;
+    bp->more_tries = 0;
+    bp->total_tries++;
+
+    lmcf = ngx_stream_get_module_main_conf(s, ngx_stream_lua_module);
+
+    /* balancer_by_lua does not support yielding and
+     * there cannot be any conflicts among concurrent sessions,
+     * thus it is safe to store the peer data in the main conf.
+     */
+    lmcf->balancer_peer_data = bp;
+
+    rc = lscf->balancer.handler(s, lscf, L);
+
+    if (rc == NGX_ERROR) {
+        return NGX_ERROR;
+    }
+
+    if (ctx->exited && ctx->exit_code != NGX_OK) {
+        rc = ctx->exit_code;
+        if (rc == NGX_ERROR || rc == NGX_BUSY || rc == NGX_DECLINED) {
+            return rc;
+        }
+
+        if (rc > NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
+
+    if (bp->sockaddr && bp->socklen) {
+        pc->sockaddr = bp->sockaddr;
+        pc->socklen = bp->socklen;
+        pc->cached = 0;
+        pc->connection = NULL;
+        pc->name = bp->host;
+
+        bp->rrp.peers->single = 0;
+
+        if (bp->more_tries) {
+            s->upstream->peer.tries += bp->more_tries;
+        }
+
+        dd("tries: %d", (int) s->upstream->peer.tries);
+
+        return NGX_OK;
+    }
+
+    return ngx_stream_upstream_get_round_robin_peer(pc, &bp->rrp);
+}
+
+
+static ngx_int_t
+ngx_stream_lua_balancer_by_chunk(lua_State *L, ngx_stream_session_t *s)
+{
+    u_char                  *err_msg;
+    size_t                   len;
+    ngx_int_t                rc;
+
+    /* init nginx context in Lua VM */
+    ngx_stream_lua_set_session(L, s);
+    ngx_stream_lua_create_new_globals_table(L, 0 /* narr */, 1 /* nrec */);
+
+    /*  {{{ make new env inheriting main thread's globals table */
+    lua_createtable(L, 0, 1 /* nrec */);   /* the metatable for the new env */
+    ngx_stream_lua_get_globals_table(L);
+    lua_setfield(L, -2, "__index");
+    lua_setmetatable(L, -2);    /*  setmetatable({}, {__index = _G}) */
+    /*  }}} */
+
+    lua_setfenv(L, -2);    /*  set new running env for the code closure */
+
+    lua_pushcfunction(L, ngx_stream_lua_traceback);
+    lua_insert(L, 1);  /* put it under chunk and args */
+
+    /*  protected call user code */
+    rc = lua_pcall(L, 0, 1, 1);
+
+    lua_remove(L, 1);  /* remove traceback function */
+
+    dd("rc == %d", (int) rc);
+
+    if (rc != 0) {
+        /*  error occurred when running loaded code */
+        err_msg = (u_char *) lua_tolstring(L, -1, &len);
+
+        if (err_msg == NULL) {
+            err_msg = (u_char *) "unknown reason";
+            len = sizeof("unknown reason") - 1;
+        }
+
+        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "failed to run balancer_by_lua*: %*s", len, err_msg);
+
+        lua_settop(L, 0); /*  clear remaining elems on stack */
+
+        return NGX_ERROR;
+    }
+
+    lua_settop(L, 0); /*  clear remaining elems on stack */
+    return rc;
+}
+
+
+void
+ngx_stream_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+    ngx_uint_t state)
+{
+    ngx_stream_lua_balancer_peer_data_t  *bp = data;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, pc->log, 0,
+                   "lua balancer free peer, tries: %ui", pc->tries);
+
+    if (bp->sockaddr && bp->socklen) {
+        if (pc->tries) {
+            pc->tries--;
+        }
+
+        return;
+    }
+
+    /* fallback */
+
+    ngx_stream_upstream_free_round_robin_peer(pc, data, state);
+}
+
+
+#ifndef NGX_LUA_NO_FFI_API
+
+int
+ngx_stream_lua_ffi_balancer_set_current_peer(ngx_stream_session_t *s,
+    const u_char *addr, size_t addr_len, int port, char **err)
+{
+    ngx_url_t              url;
+    ngx_stream_lua_ctx_t    *ctx;
+    ngx_stream_upstream_t   *u;
+
+    ngx_stream_lua_main_conf_t           *lmcf;
+    ngx_stream_lua_balancer_peer_data_t  *bp;
+
+    if (s == NULL) {
+        *err = "no session found";
+        return NGX_ERROR;
+    }
+
+    ctx = ngx_stream_get_module_ctx(s, ngx_stream_lua_module);
+    if (ctx == NULL) {
+        *err = "no ctx found";
+        return NGX_ERROR;
+    }
+
+    if ((ctx->context & NGX_STREAM_LUA_CONTEXT_BALANCER) == 0) {
+        *err = "API disabled in the current context";
+        return NGX_ERROR;
+    }
+
+    u = s->upstream;
+
+    if (u == NULL) {
+        *err = "no upstream found";
+        return NGX_ERROR;
+    }
+
+    lmcf = ngx_stream_get_module_main_conf(s, ngx_stream_lua_module);
+
+    /* we cannot read s->upstream->peer.data here directly because
+     * it could be overridden by other modules like
+     * ngx_stream_upstream_keepalive_module.
+     */
+    bp = lmcf->balancer_peer_data;
+    if (bp == NULL) {
+        *err = "no upstream peer data found";
+        return NGX_ERROR;
+    }
+
+    ngx_memzero(&url, sizeof(ngx_url_t));
+
+    url.url.data = ngx_palloc(s->connection->pool, addr_len);
+    if (url.url.data == NULL) {
+        *err = "no memory";
+        return NGX_ERROR;
+    }
+
+    ngx_memcpy(url.url.data, addr, addr_len);
+
+    url.url.len = addr_len;
+    url.default_port = (in_port_t) port;
+    url.uri_part = 0;
+    url.no_resolve = 1;
+
+    if (ngx_parse_url(s->connection->pool, &url) != NGX_OK) {
+        if (url.err) {
+            *err = url.err;
+        }
+
+        return NGX_ERROR;
+    }
+
+    if (url.addrs && url.addrs[0].sockaddr) {
+        bp->sockaddr = url.addrs[0].sockaddr;
+        bp->socklen = url.addrs[0].socklen;
+        bp->host = &url.addrs[0].name;
+
+    } else {
+        *err = "no host allowed";
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+
+int
+ngx_stream_lua_ffi_balancer_set_more_tries(ngx_stream_session_t *s,
+    int count, char **err)
+{
+    ngx_stream_lua_ctx_t    *ctx;
+    ngx_stream_upstream_t   *u;
+
+    ngx_stream_lua_main_conf_t           *lmcf;
+    ngx_stream_lua_balancer_peer_data_t  *bp;
+
+    if (s == NULL) {
+        *err = "no session found";
+        return NGX_ERROR;
+    }
+
+    ctx = ngx_stream_get_module_ctx(s, ngx_stream_lua_module);
+    if (ctx == NULL) {
+        *err = "no ctx found";
+        return NGX_ERROR;
+    }
+
+    if ((ctx->context & NGX_STREAM_LUA_CONTEXT_BALANCER) == 0) {
+        *err = "API disabled in the current context";
+        return NGX_ERROR;
+    }
+
+    u = s->upstream;
+
+    if (u == NULL) {
+        *err = "no upstream found";
+        return NGX_ERROR;
+    }
+
+    lmcf = ngx_stream_get_module_main_conf(s, ngx_stream_lua_module);
+
+    bp = lmcf->balancer_peer_data;
+    if (bp == NULL) {
+        *err = "no upstream peer data found";
+        return NGX_ERROR;
+    }
+
+    /* TODO: respect the proxy_next_upstream_tries
+     * but it's hard to get the value for now.
+     */
+
+    *err = NULL;
+
+    bp->more_tries = count;
+    return NGX_OK;
+}
+
+#endif  /* NGX_LUA_NO_FFI_API */

--- a/src/ngx_stream_lua_balancer.h
+++ b/src/ngx_stream_lua_balancer.h
@@ -1,0 +1,27 @@
+
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef _NGX_STREAM_LUA_BALANCER_H_INCLUDED_
+#define _NGX_STREAM_LUA_BALANCER_H_INCLUDED_
+
+
+#include "ngx_stream_lua_common.h"
+
+
+ngx_int_t ngx_stream_lua_balancer_handler_inline(ngx_stream_session_t *s,
+    ngx_stream_lua_srv_conf_t *lscf, lua_State *L);
+
+ngx_int_t ngx_stream_lua_balancer_handler_file(ngx_stream_session_t *s,
+    ngx_stream_lua_srv_conf_t *lscf, lua_State *L);
+
+char *ngx_stream_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+char *ngx_stream_lua_balancer_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+
+#endif /* _NGX_STREAM_LUA_BALANCER_H_INCLUDED_ */

--- a/src/ngx_stream_lua_control.c
+++ b/src/ngx_stream_lua_control.c
@@ -57,6 +57,7 @@ ngx_stream_lua_ngx_exit(lua_State *L)
     }
 
     ngx_stream_lua_check_context(L, ctx, NGX_STREAM_LUA_CONTEXT_CONTENT
+                                 | NGX_STREAM_LUA_CONTEXT_BALANCER
                                  | NGX_STREAM_LUA_CONTEXT_TIMER);
 
     rc = (ngx_int_t) luaL_checkinteger(L, 1);
@@ -68,6 +69,10 @@ ngx_stream_lua_ngx_exit(lua_State *L)
 
     ngx_log_debug1(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
                    "stream lua exit with code %i", ctx->exit_code);
+
+    if (ctx->context & NGX_STREAM_LUA_CONTEXT_BALANCER) {
+        return 0;
+    }
 
     dd("calling yield");
     return lua_yield(L, 0);
@@ -145,6 +150,7 @@ ngx_stream_lua_ffi_exit(ngx_stream_session_t *s, int status, u_char *err,
     }
 
     if (ngx_stream_lua_ffi_check_context(ctx, NGX_STREAM_LUA_CONTEXT_CONTENT
+                                         | NGX_STREAM_LUA_CONTEXT_BALANCER
                                          | NGX_STREAM_LUA_CONTEXT_TIMER,
                                          err, errlen)
         != NGX_OK)
@@ -157,6 +163,10 @@ ngx_stream_lua_ffi_exit(ngx_stream_session_t *s, int status, u_char *err,
 
     ngx_log_debug1(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
                    "stream lua exit with code %i", ctx->exit_code);
+
+    if (ctx->context & NGX_STREAM_LUA_CONTEXT_BALANCER) {
+        return NGX_DONE;
+    }
 
     return NGX_OK;
 }

--- a/src/ngx_stream_lua_module.c
+++ b/src/ngx_stream_lua_module.c
@@ -14,6 +14,7 @@
 #include "ngx_stream_lua_common.h"
 #include "ngx_stream_lua_directive.h"
 #include "ngx_stream_lua_contentby.h"
+#include "ngx_stream_lua_balancer.h"
 #include "ngx_stream_lua_semaphore.h"
 #include "ngx_stream_lua_initby.h"
 #include "ngx_stream_lua_initworkerby.h"
@@ -103,6 +104,20 @@ static ngx_command_t  ngx_stream_lua_commands[] = {
       NGX_STREAM_SRV_CONF_OFFSET,
       0,
       (void *) ngx_stream_lua_content_handler_file },
+
+    { ngx_string("balancer_by_lua_block"),
+      NGX_STREAM_UPS_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
+      ngx_stream_lua_balancer_by_lua_block,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      0,
+      (void *) ngx_stream_lua_balancer_handler_inline },
+
+    { ngx_string("balancer_by_lua_file"),
+      NGX_STREAM_UPS_CONF|NGX_CONF_TAKE1,
+      ngx_stream_lua_balancer_by_lua,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      0,
+      (void *) ngx_stream_lua_balancer_handler_file },
 
     { ngx_string("lua_max_running_timers"),
       NGX_STREAM_MAIN_CONF|NGX_CONF_TAKE1,

--- a/src/ngx_stream_lua_phase.c
+++ b/src/ngx_stream_lua_phase.c
@@ -58,6 +58,10 @@ ngx_stream_lua_ngx_get_phase(lua_State *L)
         lua_pushliteral(L, "timer");
         break;
 
+    case NGX_STREAM_LUA_CONTEXT_BALANCER:
+        lua_pushliteral(L, "balancer");
+        break;
+
     default:
         return luaL_error(L, "unknown phase: %d", (int) ctx->context);
     }

--- a/src/ngx_stream_lua_util.h
+++ b/src/ngx_stream_lua_util.h
@@ -88,6 +88,7 @@ void ngx_stream_lua_set_multi_value_table(lua_State *L, int index);
      : (c) == NGX_STREAM_LUA_CONTEXT_LOG ? "log_by_lua*"                     \
      : (c) == NGX_STREAM_LUA_CONTEXT_TIMER ? "ngx.timer"                     \
      : (c) == NGX_STREAM_LUA_CONTEXT_INIT_WORKER ? "init_worker_by_lua*"     \
+     : (c) == NGX_STREAM_LUA_CONTEXT_BALANCER ? "balancer_by_lua*"           \
      : "(unknown)")
 
 

--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -1,0 +1,207 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua::Stream 'no_plan';
+#worker_connections(1014);
+#master_on();
+#workers(2);
+#log_level('warn');
+
+repeat_each(2);
+
+#plan tests => repeat_each() * (blocks() * 4 + 9);
+
+#no_diff();
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: simple logging
+--- stream_config
+    upstream backend {
+        server 0.0.0.1:80;
+        balancer_by_lua_block {
+            print("hello from balancer by lua!")
+        }
+    }
+--- stream_server_config
+    proxy_pass backend;
+--- error_log eval
+[
+'[lua] balancer_by_lua:2: hello from balancer by lua! while connecting to upstream,',
+qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "0\.0\.0\.1:80"},
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 2: exit 403
+--- stream_config
+    upstream backend {
+        server 0.0.0.1:80;
+        balancer_by_lua_block {
+            print("hello from balancer by lua!")
+            ngx.exit(403)
+        }
+    }
+--- stream_server_config
+        proxy_pass backend;
+--- error_log
+[lua] balancer_by_lua:2: hello from balancer by lua! while connecting to upstream,
+--- no_error_log eval
+[
+'[warn]',
+'[error]',
+qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "0\.0\.0\.1:80"},
+]
+
+
+
+=== TEST 3: exit OK
+--- stream_config
+    upstream backend {
+        server 0.0.0.1:80;
+        balancer_by_lua_block {
+            print("hello from balancer by lua!")
+            ngx.exit(ngx.OK)
+        }
+    }
+--- stream_server_config
+        proxy_pass backend;
+--- error_log eval
+[
+'[lua] balancer_by_lua:2: hello from balancer by lua! while connecting to upstream,',
+qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "0\.0\.0\.1:80"},
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 4: ngx.var works
+--- stream_config
+    upstream backend {
+        server 0.0.0.1:80;
+        balancer_by_lua_block {
+            print("pid = ", ngx.var.pid)
+        }
+    }
+--- stream_server_config
+        proxy_pass backend;
+--- error_log eval
+[
+qr{pid = \d+},
+qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "0\.0\.0\.1:80"},
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 5: simple logging (by_lua_file)
+--- stream_config
+    upstream backend {
+        server 0.0.0.1:80;
+        balancer_by_lua_file html/a.lua;
+    }
+--- stream_server_config
+        proxy_pass backend;
+--- user_files
+>>> a.lua
+print("hello from balancer by lua!")
+--- error_log eval
+[
+'[lua] a.lua:1: hello from balancer by lua! while connecting to upstream,',
+qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "0\.0\.0\.1:80"},
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 6: cosockets are disabled
+--- stream_config
+    upstream backend {
+        server 0.0.0.1:80;
+        balancer_by_lua_block {
+            local sock, err = ngx.socket.tcp()
+        }
+    }
+--- stream_server_config
+        proxy_pass backend;
+--- error_log eval
+qr/\[error\] .*? failed to run balancer_by_lua\*: balancer_by_lua:2: API disabled in the context of balancer_by_lua\*/
+
+
+
+=== TEST 7: ngx.sleep is disabled
+--- stream_config
+    upstream backend {
+        server 0.0.0.1:80;
+        balancer_by_lua_block {
+            ngx.sleep(0.1)
+        }
+    }
+--- stream_server_config
+        proxy_pass backend;
+--- error_log eval
+qr/\[error\] .*? failed to run balancer_by_lua\*: balancer_by_lua:2: API disabled in the context of balancer_by_lua\*/
+
+
+
+=== TEST 8: get_phase
+--- stream_config
+    upstream backend {
+        server 0.0.0.1:80;
+        balancer_by_lua_block {
+            print("I am in phase ", ngx.get_phase())
+        }
+    }
+--- stream_server_config
+        proxy_pass backend;
+--- grep_error_log eval: qr/I am in phase \w+/
+--- grep_error_log_out
+I am in phase balancer
+--- error_log eval
+qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "0\.0\.0\.1:80"}
+--- no_error_log
+[error]
+
+
+
+=== TEST 9: code cache off
+--- stream_config
+    lua_package_path "t/servroot/html/?.lua;;";
+
+    lua_code_cache off;
+
+    upstream backend {
+        server 127.0.0.1:1989;
+        balancer_by_lua_block {
+            if not package.loaded.me then
+                package.loaded.me = 0
+            end
+
+            package.loaded.me = package.loaded.me + 1
+
+            ngx.log(ngx.NOTICE, "me: ", package.loaded.me)
+        }
+    }
+
+    server {
+        listen 1989;
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- stream_server_config
+        proxy_pass backend;
+--- stream_response
+ok
+--- grep_error_log eval: qr/\bme: \w+/
+--- grep_error_log_out
+me: 1
+--- no_error_log
+[error]


### PR DESCRIPTION
For now, only `set_current_peer` and `set_more_tries`(not respect `proxy_next_upstream_tries`)  are provided.
1. for `get_last_failure`, there is only one fail status, so we do not need it?
2. for `set_timeouts`
   the `connect_timeout` only in `ngx_stream_proxy_srv_conf_t`,
   and it only support `proxy_connect_timeout` and `proxy_timeout` (no proxy_read_timeout and proxy_send_tiemout like http system does), so I suggest just mark it to do for now.
3. for `set_more_tries`
   Seems we need to patch to the nginx core to get the configured max retry num, so just not respect `proxy_next_upstream_tries` for now, marked it's todo.

The nginx stream system is growing, so I think it's better to not patch for the nginx base code.

This PR is basically from lua-nginx-module & learn much from @rshriram @splitice #30 
