### PR TITLE
adjust t/090-log-socket-errors.t to avoid 8.8.8.8:80 connect success

### DIFF
--- a/t/090-log-socket-errors.t
+++ b/t/090-log-socket-errors.t
@@ -1,5 +1,6 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
 use Test::Nginx::Socket::Lua::Stream;
+use Cwd qw(cwd);
 #worker_connections(1014);
 #master_on();
 #workers(2);
@@ -9,6 +10,20 @@ repeat_each(2);
 
 plan tests => repeat_each() * (blocks() * 3);
 
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    server {
+        listen 12355;
+        location = / {
+            content_by_lua_block {
+                ngx.sleep(20)
+                ngx.say('foo');
+            }
+        }
+    }
+};
+
 #no_diff();
 #no_long_string();
 run_tests();
@@ -16,12 +31,18 @@ run_tests();
 __DATA__
 
 === TEST 1: log socket errors off (tcp)
+--- http_config eval: $::HttpConfig
 --- stream_server_config
-    lua_socket_connect_timeout 1ms;
+    lua_socket_read_timeout 1ms;
     lua_socket_log_errors off;
     content_by_lua_block {
             local sock = ngx.socket.tcp()
-            local ok, err = sock:connect("8.8.8.8", 80)
+            local ok, err = sock:connect("127.0.0.1", 12355)
+            if not ok then
+                ngx.say("can not connect")
+            end
+
+            local line, err, partial = sock:receive()
             ngx.say(err)
     }
 
@@ -34,12 +55,18 @@ timeout
 
 
 === TEST 2: log socket errors on (tcp)
+--- http_config eval: $::HttpConfig
 --- stream_server_config
-    lua_socket_connect_timeout 1ms;
+    lua_socket_read_timeout 1ms;
     lua_socket_log_errors on;
     content_by_lua_block {
             local sock = ngx.socket.tcp()
-            local ok, err = sock:connect("8.8.8.8", 80)
+            local ok, err = sock:connect("127.0.0.1", 12355)
+            if not ok then
+                ngx.say("can not connect")
+            end
+
+            local line, err, partial = sock:receive()
             ngx.say(err)
     }
 
@@ -47,17 +74,18 @@ timeout
 --- stream_response
 timeout
 --- error_log
-lua tcp socket connect timed out
+lua tcp socket read timed out
 
 
 
 === TEST 3: log socket errors on (udp)
+--- http_config eval: $::HttpConfig
 --- stream_server_config
     lua_socket_log_errors on;
     lua_socket_read_timeout 1ms;
     content_by_lua_block {
             local sock = ngx.socket.udp()
-            local ok, err = sock:setpeername("8.8.8.8", 80)
+            local ok, err = sock:setpeername("127.0.0.1", 12355)
             ok, err = sock:receive()
             ngx.say(err)
     }
@@ -71,12 +99,13 @@ lua udp socket read timed out
 
 
 === TEST 4: log socket errors off (udp)
+--- http_config eval: $::HttpConfig
 --- stream_server_config
     lua_socket_log_errors off;
     lua_socket_read_timeout 1ms;
     content_by_lua_block {
             local sock = ngx.socket.udp()
-            local ok, err = sock:setpeername("8.8.8.8", 80)
+            local ok, err = sock:setpeername("127.0.0.1", 12355)
             ok, err = sock:receive()
             ngx.say(err)
     }


### PR DESCRIPTION
I found that the travis may be [able to connect to the 8.8.8.8:80](https://travis-ci.org/rainingmaster/stream-lua-nginx-module/jobs/181576447#L738), which will affect the 090-log-socket-errors.t test cases. So make some changes to this test cases.

Thx for @doujiang24 's help~
