### PR TITLE
synced to meta-lua-nginx-module #18222ed for balancer status code

### DIFF
--- a/src/ngx_stream_lua_balancer.c
+++ b/src/ngx_stream_lua_balancer.c
@@ -344,7 +344,11 @@ ngx_stream_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
         rc = ctx->exit_code;
         if (rc == NGX_ERROR
             || rc == NGX_BUSY
-            || rc == NGX_DECLINED        ) {
+            || rc == NGX_DECLINED
+#ifdef HAVE_BALANCER_STATUS_CODE_PATCH
+            || rc >= NGX_STREAM_SPECIAL_RESPONSE
+#endif
+        ) {
             return rc;
         }
 

--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -49,6 +49,10 @@ qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:1234 failed .*?, upstream: "0\.0\.0\.1
         proxy_pass backend;
 --- error_log
 [lua] balancer_by_lua:2: hello from balancer by lua! while connecting to upstream,
+lua exit with code 403
+proxy connect: 403
+finalize stream proxy: 403
+finalize stream session: 403
 --- no_error_log eval
 [
 '[warn]',


### PR DESCRIPTION
support.