### PR TITLE
stream bugfix: consume preread buffer first when reading request sock…

### DIFF
--- a/t/023-preread/req-socket.t
+++ b/t/023-preread/req-socket.t
@@ -153,3 +153,67 @@ done
 
 
 
+=== TEST 6: read from preread buffer
+--- stream_server_config
+    ssl_preread on;
+
+    preread_by_lua_block {
+        local sock, err = ngx.req.socket()
+        if sock then
+            ngx.say("got the request socket")
+        else
+            ngx.say("failed to get the request socket: ", err)
+        end
+
+        for i = 1, 2 do
+            local data, err, part = sock:receive(5)
+            if data then
+                ngx.say("received: ", data)
+            else
+                ngx.say("failed to receive: ", err, " [", part, "]")
+            end
+        end
+    }
+    content_by_lua return;
+--- stream_request
+hello world
+--- stream_response
+got the request socket
+received: hello
+received:  worl
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: small preread buffer
+--- stream_server_config
+    ssl_preread on;
+    preread_buffer_size 5;
+
+    preread_by_lua_block {
+        local sock, err = ngx.req.socket()
+        if sock then
+            ngx.say("got the request socket")
+        else
+            ngx.say("failed to get the request socket: ", err)
+        end
+
+        for i = 1, 2 do
+            local data, err, part = sock:receive(5)
+            if data then
+                ngx.say("received: ", data)
+            else
+                ngx.say("failed to receive: ", err, " [", part, "]")
+            end
+        end
+    }
+    content_by_lua return;
+--- stream_request
+hello world
+--- stream_response
+got the request socket
+received: hello
+received:  worl
+--- no_error_log
+[error]

--- a/t/023-preread/req-socket.t
+++ b/t/023-preread/req-socket.t
@@ -163,6 +163,7 @@ done
             ngx.say("got the request socket")
         else
             ngx.say("failed to get the request socket: ", err)
+            return
         end
 
         for i = 1, 2 do
@@ -171,6 +172,7 @@ done
                 ngx.say("received: ", data)
             else
                 ngx.say("failed to receive: ", err, " [", part, "]")
+                return
             end
         end
     }
@@ -197,6 +199,7 @@ received:  worl
             ngx.say("got the request socket")
         else
             ngx.say("failed to get the request socket: ", err)
+            return
         end
 
         for i = 1, 2 do
@@ -205,6 +208,7 @@ received:  worl
                 ngx.say("received: ", data)
             else
                 ngx.say("failed to receive: ", err, " [", part, "]")
+                return
             end
         end
     }


### PR DESCRIPTION
…et. #6d6815c

Changes were generated from: https://github.com/openresty/meta-lua-nginx-module/pull/8.

Note that we also removed the branch containing `u->body_downstream` as those (non-raw socket) were never supported in the stream subsystem.