### PR TITLE
bugfix: when only Lua preread handler is present and content handler is

### DIFF
--- a/t/058-tcp-socket.t
+++ b/t/058-tcp-socket.t
@@ -3074,7 +3074,7 @@ failed to setkeepalive: closed
 
 
 
-=== TEST 62: TEST 62: the upper bound of port range should be 2^16 - 1
+=== TEST 57: TEST 62: the upper bound of port range should be 2^16 - 1
 --- stream_server_config
     content_by_lua_block {
         local sock, err = ngx.socket.connect("127.0.0.1", 65536)
@@ -3089,7 +3089,8 @@ failed to connect: bad port number: 65536
 [error]
 
 
-=== TEST 63: TCP socket GC'ed in preread phase without Lua content phase
+
+=== TEST 58: TCP socket GC'ed in preread phase without Lua content phase
 --- stream_server_config
     lua_socket_connect_timeout 1s;
     resolver $TEST_NGINX_RESOLVER ipv6=off;

--- a/t/087-udp-socket.t
+++ b/t/087-udp-socket.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua::Stream;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (3 * blocks() + 12);
+plan tests => repeat_each() * (3 * blocks() + 14);
 
 our $HtmlDir = html_dir;
 
@@ -885,3 +885,33 @@ qr/runtime error: content_by_lua\(nginx\.conf:\d+\):12: bad request/
 failed to connect: bad port number: 65536
 --- no_error_log
 [error]
+
+
+
+=== TEST 21: UDP socket GC'ed in preread phase without Lua content phase
+--- stream_server_config
+    preread_by_lua_block {
+        do
+            local udpsock = ngx.socket.udp()
+
+            local res, err = udpsock:setpeername("127.0.0.1", 1234)
+            if not res then
+                ngx.log(ngx.ERR, err)
+            end
+        end
+
+        ngx.timer.at(0, function()
+            collectgarbage()
+            ngx.log(ngx.WARN, "GC cycle done")
+        end)
+    }
+
+    return 1;
+
+--- stream_response chomp
+1
+--- no_error_log
+[error]
+--- error_log
+cleanup lua udp socket upstream request
+GC cycle done

--- a/t/087-udp-socket.t
+++ b/t/087-udp-socket.t
@@ -870,7 +870,7 @@ qr/runtime error: content_by_lua\(nginx\.conf:\d+\):12: bad request/
 
 
 
-=== TEST 20: the upper bound of port range should be 2^16 - 1
+=== TEST 18: the upper bound of port range should be 2^16 - 1
 --- stream_config eval
     "lua_package_path '$::HtmlDir/?.lua;./?.lua';"
 --- stream_server_config
@@ -888,7 +888,7 @@ failed to connect: bad port number: 65536
 
 
 
-=== TEST 21: UDP socket GC'ed in preread phase without Lua content phase
+=== TEST 19: UDP socket GC'ed in preread phase without Lua content phase
 --- stream_server_config
     preread_by_lua_block {
         do


### PR DESCRIPTION
non-Lua, cleanup hooks will be incorrectly skipped. #4d0361f

Changes were generated from https://github.com/openresty/meta-lua-nginx-module/pull/9.

To reproduce, simply run the added test without this PR using no-pool NGINX.

`stream` subsystem does not support cleanup handler natively, so we added emulation for such functionality inside `stream_lua`. However, those cleanup handlers will only be executed if "request" is terminated using `ngx_stream_lua_finalize_real_request()`. Since this function is `stream_lua` specific, content phase handlers like the built-in `return` directive will **not** execute those cleanup hooks.

Later on when the `__gc` metamethod on the cosocket udata is executed in another "request", it will attempt to dereference the old "request" which would have been freed already, thus causing the segfault.

This PR attaches the cleanup handlers to the connection's pool cleanup list to ensure they will always be executed regardless which content handler the server uses. Later on when Lua decides to GC the udata the `__gc` metamethod will notice that `u->cleanup` is already `NULL` and will not attempt to run the finalizer (and dereference the "request").