### PR TITLE
Enable FFI in stream module; add SSL apis

### DIFF
--- a/src/ngx_stream_lua_common.h
+++ b/src/ngx_stream_lua_common.h
@@ -9,11 +9,6 @@
 #define _NGX_STREAM_LUA_COMMON_H_INCLUDED_
 
 
-#ifndef NGX_LUA_NO_FFI_API
-#define NGX_LUA_NO_FFI_API
-#endif
-
-
 #include <nginx.h>
 #include <ngx_core.h>
 #include <ngx_stream.h>

--- a/src/ngx_stream_lua_common.h
+++ b/src/ngx_stream_lua_common.h
@@ -118,6 +118,7 @@
 #define NGX_STREAM_LUA_CONTEXT_INIT_WORKER                          0x0008
 #define NGX_STREAM_LUA_CONTEXT_BALANCER                             0x0010
 #define NGX_STREAM_LUA_CONTEXT_PREREAD                              0x0020
+#define NGX_STREAM_LUA_CONTEXT_SSL_CERT                             0x0040
 
 
 #ifndef NGX_LUA_NO_FFI_API

--- a/src/ngx_stream_lua_control.c
+++ b/src/ngx_stream_lua_control.c
@@ -157,24 +157,18 @@ ngx_stream_lua_ffi_exit(ngx_stream_lua_request_t *r, int status, u_char *err,
         return NGX_ERROR;
     }
 
-    if (ngx_stream_lua_ffi_check_context(ctx, NGX_STREAM_LUA_CONTEXT_REWRITE
-                                         | NGX_STREAM_LUA_CONTEXT_ACCESS
+    if (ngx_stream_lua_ffi_check_context(ctx, NGX_STREAM_LUA_CONTEXT_PREREAD
                                          | NGX_STREAM_LUA_CONTEXT_CONTENT
                                          | NGX_STREAM_LUA_CONTEXT_TIMER
-                                         | NGX_STREAM_LUA_CONTEXT_HEADER_FILTER
                                          | NGX_STREAM_LUA_CONTEXT_BALANCER
                                          | NGX_STREAM_LUA_CONTEXT_SSL_CERT
-                                         | NGX_STREAM_LUA_CONTEXT_SSL_SESS_STORE
-                                        | NGX_STREAM_LUA_CONTEXT_SSL_SESS_FETCH,
-                                         err, errlen)
+                                         , err, errlen)
         != NGX_OK)
     {
         return NGX_ERROR;
     }
 
-    if (ctx->context & (NGX_STREAM_LUA_CONTEXT_SSL_CERT
-                        | NGX_STREAM_LUA_CONTEXT_SSL_SESS_STORE
-                        | NGX_STREAM_LUA_CONTEXT_SSL_SESS_FETCH))
+    if (ctx->context & (NGX_STREAM_LUA_CONTEXT_SSL_CERT))
     {
 
 #if (NGX_STREAM_SSL)
@@ -185,9 +179,6 @@ ngx_stream_lua_ffi_exit(ngx_stream_lua_request_t *r, int status, u_char *err,
         ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
                        "lua exit with code %d", status);
 
-        if (ctx->context == NGX_STREAM_LUA_CONTEXT_SSL_SESS_STORE) {
-            return NGX_DONE;
-        }
 
         return NGX_OK;
 
@@ -205,8 +196,7 @@ ngx_stream_lua_ffi_exit(ngx_stream_lua_request_t *r, int status, u_char *err,
     ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
                    "lua exit with code %i", ctx->exit_code);
 
-    if (ctx->context & (NGX_STREAM_LUA_CONTEXT_HEADER_FILTER
-                        | NGX_STREAM_LUA_CONTEXT_BALANCER))
+    if (ctx->context & (NGX_STREAM_LUA_CONTEXT_BALANCER))
     {
         return NGX_DONE;
     }

--- a/src/ngx_stream_lua_log.c
+++ b/src/ngx_stream_lua_log.c
@@ -314,6 +314,53 @@ ngx_stream_lua_inject_log_consts(lua_State *L)
     /* }}} */
 }
 
+#ifndef NGX_LUA_NO_FFI_API
+
+int
+ngx_stream_lua_ffi_errlog_get_sys_filter_level(ngx_stream_lua_request_t *r)
+{
+    ngx_log_t                   *log;
+    int                          log_level;
+
+    if (r->session && r->session->connection && r->session->connection->log) {
+        log = r->session->connection->log;
+
+    } else {
+        log = ngx_cycle->log;
+    }
+
+    log_level = log->log_level;
+    if (log_level == NGX_LOG_DEBUG_ALL) {
+        log_level = NGX_LOG_DEBUG;
+    }
+
+    return log_level;
+}
+
+
+int
+ngx_stream_lua_ffi_raw_log(ngx_stream_lua_request_t *r, int level, u_char *s,
+    size_t s_len)
+{
+    ngx_log_t           *log;
+
+    if (level > NGX_LOG_DEBUG || level < NGX_LOG_STDERR) {
+        return NGX_ERROR;
+    }
+
+    if (r->session && r->session->connection && r->session->connection->log) {
+        log = r->session->connection->log;
+
+    } else {
+        log = ngx_cycle->log;
+    }
+
+    ngx_log_error((unsigned) level, log, 0, "%*s", s_len, s);
+
+    return NGX_OK;
+}
+
+#endif
 
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_stream_lua_ssl.c
+++ b/src/ngx_stream_lua_ssl.c
@@ -10,6 +10,9 @@
 #include "ddebug.h"
 
 
+#include "ngx_stream_lua_util.h"
+
+
 #if (NGX_STREAM_SSL)
 
 
@@ -33,6 +36,202 @@ ngx_stream_lua_ssl_init(ngx_log_t *log)
     }
 
     return NGX_OK;
+}
+
+
+/* Similar to ngx_stream_lua_sleep_resume */
+static ngx_int_t
+ngx_stream_lua_ssl_handshake_resume(ngx_stream_lua_request_t *r)
+{
+    lua_State             *vm;
+    lua_State             *L;
+    ngx_connection_t      *c;
+    ngx_int_t              rc;
+    ngx_uint_t             nreqs;
+    ngx_stream_lua_ctx_t  *ctx;
+
+    ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    ctx->resume_handler = ngx_stream_lua_wev_handler;
+
+    c = r->connection;
+
+    /* push return value */
+    L = ctx->cur_co_ctx->co;
+    lua_pushboolean(L, c->ssl->handshaked);
+
+    vm = ngx_stream_lua_get_lua_vm(r, ctx);
+    nreqs = c->requests;
+
+    rc = ngx_stream_lua_run_thread(vm, r, ctx, 1);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
+                   "lua run thread returned %d", rc);
+
+    if (rc == NGX_AGAIN) {
+        return ngx_stream_lua_run_posted_threads(c, vm, r, ctx, nreqs);
+    }
+
+    if (rc == NGX_DONE) {
+        ngx_stream_lua_finalize_request(r, NGX_DONE);
+        return ngx_stream_lua_run_posted_threads(c, vm, r, ctx, nreqs);
+    }
+
+    if (ctx->entered_content_phase) {
+        ngx_stream_lua_finalize_request(r, rc);
+        return NGX_DONE;
+    }
+
+    return rc;
+}
+
+
+/* Similar to ngx_stream_ssl_handshake_handler */
+static void
+ngx_stream_lua_ssl_handshake_handler(ngx_connection_t *c)
+{
+    ngx_stream_session_t      *s;
+    ngx_stream_lua_ctx_t      *ctx;
+    ngx_stream_lua_request_t  *r;
+
+    s = c->data;
+
+    ctx = ngx_stream_get_module_ctx(s, ngx_stream_lua_module);
+
+    dd("ctx = %p", ctx);
+
+    if (ctx == NULL) {
+        ngx_stream_finalize_session(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    if (c->read->timer_set) {
+        ngx_del_timer(c->read);
+    }
+
+    r = ctx->request;
+
+    /* XXX: should we stash the one from ngx_stream_lua_req_starttls away for this? */
+    ctx->cur_co_ctx = &ctx->entry_co_ctx;
+
+    if (ctx->entered_content_phase) {
+        (void) ngx_stream_lua_ssl_handshake_resume(r);
+
+    } else {
+        ctx->resume_handler = ngx_stream_lua_ssl_handshake_resume;
+        ngx_stream_lua_core_run_phases(r);
+    }
+}
+
+
+/* Similar to ngx_stream_ssl_init_connection */
+static ngx_int_t
+ngx_stream_lua_ssl_init_connection(ngx_connection_t *c,
+    SSL_CTX* ptr, ngx_msec_t handshake_timeout)
+{
+    ngx_int_t                    rc;
+    ngx_stream_session_t        *s;
+    ngx_stream_core_srv_conf_t  *cscf;
+    ngx_ssl_t                   *ssl;
+    ngx_pool_cleanup_t          *cln;
+
+    s = c->data;
+
+    cscf = ngx_stream_get_module_srv_conf(s, ngx_stream_core_module);
+
+    if (cscf->tcp_nodelay && ngx_tcp_nodelay(c) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    ssl = ngx_pcalloc(c->pool, sizeof(ngx_ssl_t));
+    if (ssl == NULL) {
+        return NGX_ERROR;
+    }
+
+    cln = ngx_pool_cleanup_add(c->pool, 0);
+    if (cln == NULL) {
+        return NGX_ERROR;
+    }
+
+    if (!SSL_CTX_up_ref(ptr)) {
+        return NGX_ERROR;
+    }
+
+    ssl->ctx = ptr;
+    ssl->log = c->log;
+    ssl->buffer_size = NGX_SSL_BUFSIZE;
+
+    cln->handler = ngx_ssl_cleanup_ctx;
+    cln->data = ssl;
+
+    if (ngx_ssl_create_connection(ssl, c, 0) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    rc = ngx_ssl_handshake(c);
+
+    if (rc == NGX_AGAIN) {
+        ngx_add_timer(c->read, handshake_timeout);
+
+        c->ssl->handler = ngx_stream_lua_ssl_handshake_handler;
+    }
+
+    return rc;
+}
+
+
+/* Similar to ngx_stream_ssl_init_connection */
+int
+ngx_stream_lua_req_starttls(lua_State *L)
+{
+    ngx_stream_lua_request_t  *r;
+    ngx_stream_lua_ctx_t      *ctx;
+    ngx_stream_lua_co_ctx_t   *coctx;
+    ngx_connection_t          *c;
+    SSL_CTX                   *ptr;
+    ngx_msec_t                 handshake_timeout;
+    ngx_int_t                  rc;
+
+    r = ngx_stream_lua_get_req(L);
+    if (r == NULL) {
+        return luaL_error(L, "no request found");
+    }
+
+    ptr = *(SSL_CTX**)luaL_checkudata(L, 1, "SSL_CTX*");
+    handshake_timeout = luaL_optinteger(L, 2, 60000);
+
+    ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
+    if (ctx == NULL) {
+        return luaL_error(L, "no request ctx found");
+    }
+
+    coctx = ctx->cur_co_ctx;
+    if (coctx == NULL) {
+        return luaL_error(L, "no co ctx found");
+    }
+
+    c = r->connection;
+    if (c == NULL) {
+        return luaL_error(L, "no connection found");
+    }
+
+    rc = ngx_stream_lua_ssl_init_connection(c, ptr, handshake_timeout);
+
+    if (rc == NGX_OK) {
+        lua_pushboolean(L, 1);
+        return 1;
+    }
+
+    if (rc == NGX_ERROR) {
+        lua_pushboolean(L, 0);
+        return 1;
+    }
+
+    /* rc == NGX_AGAIN */
+    return lua_yield(L, 0);
 }
 
 

--- a/src/ngx_stream_lua_ssl.h
+++ b/src/ngx_stream_lua_ssl.h
@@ -41,6 +41,8 @@ ngx_int_t ngx_stream_lua_ssl_init(ngx_log_t *log);
 extern int ngx_stream_lua_ssl_ctx_index;
 
 
+int ngx_stream_lua_req_starttls(lua_State *L);
+
 #endif
 
 

--- a/src/ngx_stream_lua_util.c
+++ b/src/ngx_stream_lua_util.c
@@ -1863,10 +1863,13 @@ ngx_stream_lua_inject_req_api(ngx_log_t *log, lua_State *L)
 {
     /* ngx.req table */
 
-    lua_createtable(L, 0 /* narr */, 24 /* nrec */);    /* .req */
+    lua_createtable(L, 0 /* narr */, 25 /* nrec */);    /* .req */
 
     lua_pushcfunction(L, ngx_stream_lua_req_socket);
     lua_setfield(L, -2, "socket");
+
+    lua_pushcfunction(L, ngx_stream_lua_req_starttls);
+    lua_setfield(L, -2, "starttls");
 
     ngx_stream_lua_inject_req_time_api(L);
 

--- a/src/ngx_stream_lua_util.c
+++ b/src/ngx_stream_lua_util.c
@@ -1868,6 +1868,7 @@ ngx_stream_lua_inject_req_api(ngx_log_t *log, lua_State *L)
     lua_pushcfunction(L, ngx_stream_lua_req_socket);
     lua_setfield(L, -2, "socket");
 
+    ngx_stream_lua_inject_req_time_api(L);
 
     lua_setfield(L, -2, "req");
 }

--- a/src/ngx_stream_lua_util.h
+++ b/src/ngx_stream_lua_util.h
@@ -123,6 +123,10 @@ ngx_stream_lua_ffi_check_context(ngx_stream_lua_ctx_t *ctx,
 #define ngx_stream_lua_ssl_get_ctx(ssl_conn)                                 \
     SSL_get_ex_data(ssl_conn, ngx_stream_lua_ssl_ctx_index)
 
+#if (OPENSSL_VERSION_NUMBER < 0x10100001L)
+#define SSL_CTX_up_ref(ctx)                                                  \
+    CRYPTO_add(&(ctx)->references, 1, CRYPTO_LOCK_SSL_CTX)
+#endif
 
 lua_State *ngx_stream_lua_init_vm(lua_State *parent_vm, ngx_cycle_t *cycle,
     ngx_pool_t *pool, ngx_stream_lua_main_conf_t *lmcf, ngx_log_t *log,


### PR DESCRIPTION
This branch is a few misc things jumbled together; let me know if you'd like it as separate PRs (and which bits).

The `balancer.set_ssl_ctx` patch requires https://trac.nginx.org/nginx/attachment/ticket/1629/0001-add-stream_session-upstream_ssl-to-configure-per-str.patch
