### PR TITLE
 tests: new test case asserting resty.core is compatible with the current version of this module.

### DIFF
--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua::Stream;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 10);
+plan tests => repeat_each() * (blocks() * 3 + 11);
 
 #no_diff();
 no_long_string();
@@ -193,7 +193,21 @@ qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:1234 failed .*?, upstream: "0\.0\.0\.1
 
 
 
-=== TEST 10: test if execeed proxy_next_upstream_limit
+=== TEST 10: ngx.balancer is compatible with this version of ngx_stream_lua_module
+--- stream_config
+    lua_package_path "../lua-resty-core/lib/?.lua;;";
+--- stream_server_config
+        content_by_lua_block {
+            require "ngx.balancer"
+        }
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+
+
+=== TEST 11: test if execeed proxy_next_upstream_limit
 --- stream_config
     lua_package_path "../lua-resty-core/lib/?.lua;;";
 
@@ -240,7 +254,7 @@ set more tries: reduced tries due to limit
 
 
 
-=== TEST 11: set_more_tries bugfix
+=== TEST 12: set_more_tries bugfix
 --- stream_config
     lua_package_path "../lua-resty-core/lib/?.lua;;";
 	proxy_next_upstream_tries 0;


### PR DESCRIPTION
This is based on _top_ of https://github.com/openresty/stream-lua-nginx-module/pull/126, which should be merged first, and this should be rebased afterwards.

This will give us visibility in case [this scenario](https://github.com/openresty/stream-lua-nginx-module/pull/118#discussion_r228663467) happens again. Currently, it is not explicit why the balancer tests are failing. This test makes it explicit to the reviewer.

If this test is judged acceptable, I will port it to the ngx_lua module as well. Suggestions for other similar tests on resty.core <-> ngx_[stream]_lua compatibility are very much welcome. I was considering a plain `resty.core` require, which ngx_lua's [154-semaphore.t](https://github.com/openresty/lua-nginx-module/blob/master/t/154-semaphore.t#L24) does, but it seems like https://github.com/openresty/stream-lua-nginx-module/commit/394591783006d5edbd891558895708e4b9c622b4 did not port this test suite to this module.

Curious to hear your thoughts here @dndx @agentzh.