### PR TITLE
misc: updated _G write guard message to be more accurate.

### DIFF
--- a/src/ngx_stream_lua_util.c
+++ b/src/ngx_stream_lua_util.c
@@ -541,7 +541,7 @@ ngx_stream_lua_inject_ngx_api(lua_State *L, ngx_stream_lua_main_conf_t *lmcf,
         const char buf[] =
             "local ngx_log = ngx.log\n"
             "local ngx_WARN = ngx.WARN\n"
-            "local type = type\n"
+            "local tostring = tostring\n"
             "local ngx_get_phase = ngx.get_phase\n"
             "local traceback = require 'debug'.traceback\n"
             "local function newindex(table, key, value)\n"
@@ -550,9 +550,11 @@ ngx_stream_lua_inject_ngx_api(lua_State *L, ngx_stream_lua_main_conf_t *lmcf,
                 "if phase == 'init_worker' or phase == 'init' then\n"
                     "return\n"
                 "end\n"
-                "ngx_log(ngx_WARN, 'stream lua attempting to write to the "
-                         "lua global variable \\'', tostring(key), "
-                         "'\\'\\n', traceback())\n"
+                "ngx_log(ngx_WARN, 'writing a global lua variable "
+                         "(\\'', tostring(key), '\\') which may lead to "
+                         "race conditions between concurrent requests, so "
+                         "prefer the use of \\'local\\' variables', "
+                         "traceback('', 2))\n"
             "end\n"
             "setmetatable(_G, { __newindex = newindex })\n"
             ;
@@ -561,8 +563,8 @@ ngx_stream_lua_inject_ngx_api(lua_State *L, ngx_stream_lua_main_conf_t *lmcf,
 
         if (rc != 0) {
             ngx_log_error(NGX_LOG_ERR, log, 0,
-                          "failed to load Lua code for the _G write guard: ",
-                          "%i: %s", rc, lua_tostring(L, -1));
+                          "failed to load Lua code (%i): %s",
+                          rc, lua_tostring(L, -1));
 
             lua_pop(L, 1);
             return;
@@ -571,7 +573,7 @@ ngx_stream_lua_inject_ngx_api(lua_State *L, ngx_stream_lua_main_conf_t *lmcf,
         rc = lua_pcall(L, 0, 0, 0);
         if (rc != 0) {
             ngx_log_error(NGX_LOG_ERR, log, 0,
-                          "failed to run Lua code for the _G write guard: %s",
+                          "failed to run Lua code (%i): %s",
                           rc, lua_tostring(L, -1));
             lua_pop(L, 1);
         }

--- a/t/157-global-var.t
+++ b/t/157-global-var.t
@@ -94,9 +94,9 @@ qr/^(2|3)$/
 --- stream_response_like chomp
 \A[12]\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?stream lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua\(.*?\):\d+: in main chunk)/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk)/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?stream lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 preread_by_lua\(nginx\.conf:\d+\):3: in main chunk/, "old foo: 1\n"]
 
 
@@ -115,9 +115,9 @@ preread_by_lua\(nginx\.conf:\d+\):3: in main chunk/, "old foo: 1\n"]
 --- stream_response_like chomp
 \A[12]\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?stream lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua\(.*?\):\d+: in main chunk, )/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk, )/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?stream lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 content_by_lua\(nginx\.conf:\d+\):3: in main chunk, \n\z/, "old foo: 1\n"]
 
 
@@ -138,9 +138,9 @@ content_by_lua\(nginx\.conf:\d+\):3: in main chunk, \n\z/, "old foo: 1\n"]
 --- stream_response_like chomp
 \A(?:nil|1)\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?stream lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua\(.*?\):\d+: in main chunk)/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk)/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?stream lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 log_by_lua\(nginx\.conf:\d+\):3: in main chunk/, "old foo: 1\n"]
 
 
@@ -167,9 +167,9 @@ log_by_lua\(nginx\.conf:\d+\):3: in main chunk/, "old foo: 1\n"]
 --- stream_response_like chomp
 \A[12]\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?stream lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua\(.*?\):\d+: in\b)/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in\b)/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?stream lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 content_by_lua\(nginx\.conf:\d+\):4: in\n\z/, "old foo: 1\n"]
 
 
@@ -196,9 +196,9 @@ content_by_lua\(nginx\.conf:\d+\):4: in\n\z/, "old foo: 1\n"]
 --- stream_response_like chomp
 \A[12]\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|write to the lua global variable '\w+')/
+qr/(old foo: \d+|writing a global lua variable \('\w+'\))/
 --- grep_error_log_out eval
-["write to the lua global variable 'foo'\n", "old foo: 1\n"]
+["writing a global lua variable \('foo'\)\n", "old foo: 1\n"]
 
 
 
@@ -217,9 +217,9 @@ qr/(old foo: \d+|write to the lua global variable '\w+')/
     }
 --- stream_server_config
         proxy_pass backend;
---- grep_error_log eval: qr/(old foo: \d+|write to the lua global variable '\w+')/
+--- grep_error_log eval: qr/(old foo: \d+|writing a global lua variable \('\w+'\))/
 --- grep_error_log_out eval
-["write to the lua global variable 'foo'\n", "old foo: 1\n"]
+["writing a global lua variable \('foo'\)\n", "old foo: 1\n"]
 --- error_log
 connect() to 0.0.0.1:1234 failed
 
@@ -239,9 +239,9 @@ connect() to 0.0.0.1:1234 failed
         }
 --- stream_response
 0
---- grep_error_log eval: qr/write to the lua global variable '\w+'/
+--- grep_error_log eval: qr/writing a global lua variable \('\w+'\)/
 --- grep_error_log_out eval
-["write to the lua global variable 'foo'\n", "write to the lua global variable '1'\n"]
+["writing a global lua variable \('foo'\)\n", "writing a global lua variable \('1'\)\n"]
 
 
 


### PR DESCRIPTION
* more appropriate message ("writing" instead of "attempting to")
* remove http/lua prefix (`ngx.log` will inject `[lua]` and `stream [lua]`
  already)
* remove unused cached global
* cache `tostring` global locally
* updated tests