### PR TITLE
change: we now print an alert when a non openresty-specific version of

### DIFF
--- a/src/ngx_stream_lua_module.c
+++ b/src/ngx_stream_lua_module.c
@@ -514,6 +514,19 @@ ngx_stream_lua_init(ngx_conf_t *cf)
     if (lmcf->lua == NULL) {
         dd("initializing lua vm");
 
+#ifndef OPENRESTY_LUAJIT
+        if (ngx_process != NGX_PROCESS_SIGNALLER && !ngx_test_config) {
+            ngx_log_error(NGX_LOG_ALERT, cf->log, 0,
+                          "detected a LuaJIT version which is not OpenResty's"
+                          "; many optimizations will be disabled and "
+                          "performance will be compromised (see "
+                          "https://github.com/openresty/luajit2 for "
+                          "OpenResty's LuaJIT or, even better, consider using "
+                          "the OpenResty releases from https://openresty.org/"
+                          "en/download.html)");
+        }
+#endif
+
 
         lmcf->lua = ngx_stream_lua_init_vm(NULL, cf->cycle, cf->pool, lmcf,
                                            cf->log, NULL);


### PR DESCRIPTION
luajit is detected since many optimizations would be missing.