### PR TITLE
synchronized to meta-lua-nginx-module #b7267fc

### DIFF
--- a/src/ngx_stream_lua_common.h
+++ b/src/ngx_stream_lua_common.h
@@ -135,8 +135,14 @@
 #endif
 
 
+#if (NGX_PTR_SIZE >= 8 && !defined(_WIN64))
 #define ngx_stream_lua_lightudata_mask(ludata)                               \
     ((void *) ((uintptr_t) (&ngx_stream_lua_##ludata) & ((1UL << 47) - 1)))
+
+#else
+#define ngx_stream_lua_lightudata_mask(ludata)                               \
+    (&ngx_stream_lua_##ludata)
+#endif
 
 
 typedef struct ngx_stream_lua_main_conf_s  ngx_stream_lua_main_conf_t;

--- a/src/ngx_stream_lua_module.c
+++ b/src/ngx_stream_lua_module.c
@@ -101,18 +101,18 @@ static ngx_command_t ngx_stream_lua_cmds[] = {
       0,
       NULL },
 
-    { ngx_string("lua_capture_error_log"),
-      NGX_STREAM_MAIN_CONF|NGX_CONF_TAKE1,
-      ngx_stream_lua_capture_error_log,
-      0,
-      0,
-      NULL },
-
     { ngx_string("lua_sa_restart"),
       NGX_STREAM_MAIN_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
       NGX_STREAM_MAIN_CONF_OFFSET,
       offsetof(ngx_stream_lua_main_conf_t, set_sa_restart),
+      NULL },
+
+    { ngx_string("lua_capture_error_log"),
+      NGX_STREAM_MAIN_CONF|NGX_CONF_TAKE1,
+      ngx_stream_lua_capture_error_log,
+      0,
+      0,
       NULL },
 
 #if (NGX_PCRE)

--- a/src/ngx_stream_lua_util.h
+++ b/src/ngx_stream_lua_util.h
@@ -17,6 +17,11 @@
 #define _NGX_STREAM_LUA_UTIL_H_INCLUDED_
 
 
+#ifdef DDEBUG
+#include "ddebug.h"
+#endif
+
+
 #include "ngx_stream_lua_common.h"
 #include "ngx_stream_lua_api.h"
 
@@ -302,7 +307,9 @@ ngx_stream_lua_create_ctx(ngx_stream_session_t *r)
     if (!llcf->enable_code_cache && r->connection->fd != (ngx_socket_t) -1) {
         lmcf = ngx_stream_get_module_main_conf(r, ngx_stream_lua_module);
 
+#ifdef DDEBUG
         dd("lmcf: %p", lmcf);
+#endif
 
         /*
          * caveats: we need to move the vm cleanup hook to the list end
@@ -362,7 +369,11 @@ ngx_stream_lua_get_lua_vm(ngx_stream_lua_request_t *r,
     }
 
     lmcf = ngx_stream_lua_get_module_main_conf(r, ngx_stream_lua_module);
+
+#ifdef DDEBUG
     dd("lmcf->lua: %p", lmcf->lua);
+#endif
+
     return lmcf->lua;
 }
 


### PR DESCRIPTION
bugfix: the lightuserdata mask was broken in WIN64.
bugfix: we now only apply the lightuserdata mask on platforms that are at least 64bits.
bugfix: the 'dd' calls in ngx_subsys_lua_util.h are now guarded by '#ifdef DDEBUG'.