### PR TITLE
bugfix: ensured the 'pcre_version' symbol is preserved and undefined when PCRE is statically linked.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,12 @@ install:
   - git clone https://github.com/openresty/mockeagain.git
   - git clone https://github.com/openresty/test-nginx.git
   - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b fix/static-libpcre https://github.com/thibaultcha/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/memc-nginx-module.git ../memc-nginx-module
   - git clone https://github.com/openresty/headers-more-nginx-module.git ../headers-more-nginx-module
   - git clone https://github.com/openresty/lua-resty-lrucache.git ../lua-resty-lrucache
-  - git clone https://github.com/openresty/lua-resty-core.git ../lua-resty-core
+  - git clone -b chore/bump-api https://github.com/thibaultcha/lua-resty-core.git ../lua-resty-core
 
 script:
   - sudo iptables -I OUTPUT 1 -p udp --dport 10086 -j REJECT

--- a/config
+++ b/config
@@ -450,5 +450,23 @@ ngx_feature_test='struct sigaction act;
 
 . auto/feature
 
+if [ $PCRE != NO -a $PCRE != YES ]; then
+    # force pcre_version symbol to be undefined when PCRE is statically linked
+
+    ngx_feature="force undefined symbols (--undefined)"
+    ngx_feature_libs="-Wl,--undefined=printf"
+    ngx_feature_name=
+    ngx_feature_run=no
+    ngx_feature_incs="#include <stdio.h>"
+    ngx_feature_path=
+    ngx_feature_test='printf("hello");'
+
+    . auto/feature
+
+    if [ $ngx_found = yes ]; then
+        CORE_LIBS="$CORE_LIBS -Wl,--undefined=pcre_version"
+    fi
+fi
+
 #CFLAGS=$"$CFLAGS -DLUA_DEFAULT_PATH='\"/usr/local/openresty/lualib/?.lua\"'"
 #CFLAGS=$"$CFLAGS -DLUA_DEFAULT_CPATH='\"/usr/local/openresty/lualib/?.so\"'"

--- a/src/api/ngx_stream_lua_api.h
+++ b/src/api/ngx_stream_lua_api.h
@@ -29,7 +29,7 @@
 /* Public API for other Nginx modules */
 
 
-#define ngx_stream_lua_version  7
+#define ngx_stream_lua_version  8
 
 
 typedef struct {


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

The API version of this module has been bumped to ensure lua-resty-core's compatibility. Currently, lua-resty-core with a statically linked PCRE prevents `resty.core.regex` and `ngx.re` from loading.

Sister PRs:

- https://github.com/openresty/lua-nginx-module/pull/1556
- https://github.com/openresty/lua-resty-core/pull/261