### PR TITLE
Add shdict set_when, safe_set_when, and store_when

### DIFF
--- a/config
+++ b/config
@@ -452,7 +452,6 @@ ngx_feature_test='struct sigaction act;
 
 if [ $PCRE != NO -a $PCRE != YES ]; then
     # force pcre_version symbol to be undefined when PCRE is statically linked
-
     ngx_feature="force undefined symbols (--undefined)"
     ngx_feature_libs="-Wl,--undefined=printf"
     ngx_feature_name=
@@ -465,6 +464,21 @@ if [ $PCRE != NO -a $PCRE != YES ]; then
 
     if [ $ngx_found = yes ]; then
         CORE_LIBS="$CORE_LIBS -Wl,--undefined=pcre_version"
+    fi
+
+    # for LLVM ld (Darwin)
+    ngx_feature="force undefined symbols (-all_load -U)"
+    ngx_feature_libs="-all_load -U printf"
+    ngx_feature_name=
+    ngx_feature_run=no
+    ngx_feature_incs="#include <stdio.h>"
+    ngx_feature_path=
+    ngx_feature_test='printf("hello");'
+
+    . auto/feature
+
+    if [ $ngx_found = yes ]; then
+        CORE_LIBS="$CORE_LIBS -all_load -U pcre_version"
     fi
 fi
 

--- a/t/062-count.t
+++ b/t/062-count.t
@@ -121,7 +121,7 @@ n = 8
         ngx.say("n = ", n)
     }
 --- stream_response
-n = 22
+n = 24
 --- no_error_log
 [error]
 


### PR DESCRIPTION
This pull request adds `set_when` and `safe_set_when` methods to `ngx.shared.DICT`.
It also adds `ngx_stream_lua_ffi_shdict_store_when` which is used in [Add shdict set_when and safe_set_when by hnakamur · Pull Request #268 · openresty/lua-resty-core](https://github.com/openresty/lua-resty-core/pull/268).

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.