### PR TITLE
feature: add FFI interface to verify SSL client certificate

### DIFF
--- a/src/ngx_stream_lua_ssl_certby.c
+++ b/src/ngx_stream_lua_ssl_certby.c
@@ -1369,6 +1369,9 @@ ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
             ngx_stream_ssl_module);
         if (sscf != NULL) {
             depth = sscf->verify_depth;
+        } else {
+            /* same as the default value of ssl_verify_depth */
+            depth = 1;
         }
     }
     SSL_set_verify_depth(ssl_conn, depth);

--- a/src/ngx_stream_lua_ssl_certby.c
+++ b/src/ngx_stream_lua_ssl_certby.c
@@ -1318,7 +1318,7 @@ failed:
 
 
 static int
-ngx_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
+ngx_stream_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
 {
     /*
      * we never terminate handshake here and user can later use
@@ -1372,7 +1372,8 @@ ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
 
     /* enable verify */
 
-    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_ssl_verify_callback);
+    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER,
+                   ngx_stream_lua_ssl_verify_callback);
 
     /* set depth */
 
@@ -1381,11 +1382,13 @@ ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
             ngx_stream_ssl_module);
         if (sscf != NULL) {
             depth = sscf->verify_depth;
+
         } else {
             /* same as the default value of ssl_verify_depth */
             depth = 1;
         }
     }
+
     SSL_set_verify_depth(ssl_conn, depth);
 
     /* set CA chain */
@@ -1444,9 +1447,9 @@ ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
 
 failed:
 
-    X509_STORE_free(ca_store);
-
     sk_X509_NAME_free(name_chain);
+
+    X509_STORE_free(ca_store);
 
     return NGX_ERROR;
 }

--- a/src/ngx_stream_lua_ssl_certby.c
+++ b/src/ngx_stream_lua_ssl_certby.c
@@ -1334,6 +1334,7 @@ int
 ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
     void *cdata, int depth, char **err)
 {
+    ngx_stream_lua_ctx_t        *ctx;
     ngx_ssl_conn_t              *ssl_conn;
     ngx_stream_ssl_conf_t       *sscf;
     STACK_OF(X509)              *chain = cdata;
@@ -1346,6 +1347,17 @@ ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
 #else
     int                         i;
 #endif
+
+    ctx = ngx_stream_get_module_ctx(r->session, ngx_stream_lua_module);
+    if (ctx == NULL) {
+        *err = "no request ctx found";
+        return NGX_ERROR;
+    }
+
+    if (!(ctx->context & NGX_STREAM_LUA_CONTEXT_SSL_CERT)) {
+        *err = "API disabled in the current context";
+        return NGX_ERROR;
+    }
 
     if (r->connection == NULL || r->connection->ssl == NULL) {
         *err = "bad request";

--- a/src/ngx_stream_lua_ssl_certby.c
+++ b/src/ngx_stream_lua_ssl_certby.c
@@ -1317,4 +1317,104 @@ failed:
 }
 
 
+static int
+ngx_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
+{
+    /*
+     * we never terminate handshake here and user can later use
+     * $ssl_client_verify to check verification result.
+     *
+     * this is consistent with Nginx behavior.
+     */
+    return 1;
+}
+
+
+int
+ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
+    int depth,
+    void *cdata, char **err)
+{
+    ngx_ssl_conn_t         *ssl_conn;
+    STACK_OF(X509)         *chain = cdata;
+    STACK_OF(X509_NAME)    *name_chain = NULL;
+    X509                   *x509 = NULL;
+    X509_NAME              *subject = NULL;
+    X509_STORE             *ca_store = NULL;
+#ifdef OPENSSL_IS_BORINGSSL
+    size_t                 i;
+#else
+    int                    i;
+#endif
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    ca_store = SSL_CTX_get_cert_store(SSL_get_SSL_CTX(ssl_conn));
+    if (ca_store == NULL) {
+        *err = "SSL_CTX_get_cert_store() failed";
+        return NGX_ERROR;
+    }
+
+    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_ssl_verify_callback);
+
+    SSL_set_verify_depth(ssl_conn, depth);
+
+    if (chain != NULL) {
+        /* construct name chain */
+
+        name_chain = sk_X509_NAME_new_null();
+        if (name_chain == NULL) {
+            *err = "sk_X509_NAME_new_null() failed";
+            return NGX_ERROR;
+        }
+
+        for (i = 0; i < sk_X509_num(chain); i++) {
+            x509 = sk_X509_value(chain, i);
+            if (x509 == NULL) {
+                *err = "sk_X509_value() failed";
+                goto failed;
+            }
+
+            /* add subject to name chain, which will be sent to client */
+            subject = X509_NAME_dup(X509_get_subject_name(x509));
+            if (subject == NULL) {
+                *err = "X509_get_subject_name() failed";
+                goto failed;
+            }
+
+            if (!sk_X509_NAME_push(name_chain, subject)) {
+                *err = "sk_X509_NAME_push() failed";
+                X509_NAME_free(subject);
+                goto failed;
+            }
+
+            /* add to trusted CA store */
+            if (X509_STORE_add_cert(ca_store, x509) == 0) {
+                *err = "X509_STORE_add_cert() failed";
+                goto failed;
+            }
+        }
+
+        SSL_set_client_CA_list(ssl_conn, name_chain);
+    }
+
+    return NGX_OK;
+
+failed:
+
+    sk_X509_NAME_free(name_chain);
+
+    return NGX_ERROR;
+}
+
+
 #endif /* NGX_STREAM_SSL */

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -728,7 +728,7 @@ lua ssl server name: "test.com"
         }
     }
 --- stream_server_config
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     proxy_pass                  unix:$TEST_NGINX_HTML_DIR/nginx.sock;
     proxy_ssl                   on;
@@ -783,7 +783,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         }
     }
 --- stream_server_config
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     proxy_pass                  unix:$TEST_NGINX_HTML_DIR/nginx.sock;
     proxy_ssl                   on;
@@ -838,7 +838,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         }
     }
 --- stream_server_config
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     proxy_pass                  unix:$TEST_NGINX_HTML_DIR/nginx.sock;
     proxy_ssl                   on;

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -62,7 +62,7 @@ ffi.cdef[[
 
     int ngx_stream_lua_ffi_ssl_clear_certs(void *r, char **err);
 
-    int ngx_stream_lua_ffi_ssl_verify_client(void *r, int depth, void *cdata, char **err);
+    int ngx_stream_lua_ffi_ssl_verify_client(void *r, void *cdata, int depth, char **err);
 
 ]]
 _EOC_
@@ -714,7 +714,7 @@ lua ssl server name: "test.com"
                 return
             end
 
-            local rc = ffi.C.ngx_stream_lua_ffi_ssl_verify_client(r, 1, cert, errmsg)
+            local rc = ffi.C.ngx_stream_lua_ffi_ssl_verify_client(r, cert, -1, errmsg)
             if rc ~= 0 then
                 ngx.log(ngx.ERR, "failed to set cdata cert: ",
                         ffi.string(errmsg[0]))
@@ -769,7 +769,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
                 return
             end
 
-            local rc = ffi.C.ngx_stream_lua_ffi_ssl_verify_client(r, 1, nil, errmsg)
+            local rc = ffi.C.ngx_stream_lua_ffi_ssl_verify_client(r, nil, -1, errmsg)
             if rc ~= 0 then
                 ngx.log(ngx.ERR, "failed to set cdata cert: ",
                         ffi.string(errmsg[0]))
@@ -824,7 +824,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
                 return
             end
 
-            local rc = ffi.C.ngx_stream_lua_ffi_ssl_verify_client(r, 1, nil, errmsg)
+            local rc = ffi.C.ngx_stream_lua_ffi_ssl_verify_client(r, nil, -1, errmsg)
             if rc ~= 0 then
                 ngx.log(ngx.ERR, "failed to set cdata cert: ",
                         ffi.string(errmsg[0]))

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -720,6 +720,8 @@ lua ssl server name: "test.com"
                         ffi.string(errmsg[0]))
                 return
             end
+
+            ffi.C.ngx_stream_lua_ffi_free_cert(cert)
         }
 
         content_by_lua_block {
@@ -732,6 +734,7 @@ lua ssl server name: "test.com"
     proxy_ssl                   on;
     proxy_ssl_certificate       ../../cert/test.crt;
     proxy_ssl_certificate_key   ../../cert/test.key;
+    proxy_ssl_session_reuse     off;
 
 --- stream_response
 SUCCESS
@@ -785,6 +788,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
     proxy_ssl                   on;
     proxy_ssl_certificate       ../../cert/test.crt;
     proxy_ssl_certificate_key   ../../cert/test.key;
+    proxy_ssl_session_reuse     off;
 
 --- stream_response
 FAILED:self signed certificate
@@ -837,6 +841,8 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
                         ffi.string(errmsg[0]))
                 return
             end
+
+            ffi.C.ngx_stream_lua_ffi_free_cert(cert)
         }
 
         content_by_lua_block {
@@ -847,6 +853,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
 --- stream_server_config
     proxy_pass                  unix:$TEST_NGINX_HTML_DIR/nginx.sock;
     proxy_ssl                   on;
+    proxy_ssl_session_reuse     off;
 
 --- stream_response
 NONE


### PR DESCRIPTION
This PR adds a FFI interface that allows users to configure SSL client certificate verification dynamically. For example, Nginx can now read SNI first and then determine whether to request a client certificate during handshake. Optionally, caller can pass in a CA list used for verification.

See https://github.com/openresty/meta-lua-nginx-module/pull/75 .

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.