### PR TITLE
chore: removed unwanted CC_TEST_FLAGS when checking LuaJIT's FFI feat…

### DIFF
--- a/config
+++ b/config
@@ -212,7 +212,6 @@ fi
 # ----------------------------------------
 
 ngx_feature="LuaJIT has FFI"
-CC_TEST_FLAGS="$ngx_lua_opt_I $CFLAGS"
 ngx_feature_libs="$ngx_module_libs"
 ngx_feature_run=no
 ngx_feature_incs="#include <lualib.h>


### PR DESCRIPTION
…ure.

We don't need the modified CC_TEST_FLAGS to pass the feature check.
And sometimes this change causes the configure script to fail.