### PR TITLE
bugfix: hide get_request API in stream subsystem

### DIFF
--- a/src/api/ngx_stream_lua_api.h
+++ b/src/api/ngx_stream_lua_api.h
@@ -53,7 +53,6 @@ typedef struct {
 
 lua_State *ngx_stream_lua_get_global_state(ngx_conf_t *cf);
 
-ngx_stream_lua_request_t *ngx_stream_lua_get_request(lua_State *L);
 
 ngx_int_t ngx_stream_lua_add_package_preload(ngx_conf_t *cf,
     const char *package, lua_CFunction func);

--- a/src/ngx_stream_lua_api.c
+++ b/src/ngx_stream_lua_api.c
@@ -35,11 +35,6 @@ ngx_stream_lua_get_global_state(ngx_conf_t *cf)
 }
 
 
-ngx_stream_lua_request_t *
-ngx_stream_lua_get_request(lua_State *L)
-{
-    return ngx_stream_lua_get_req(L);
-}
 
 
 static ngx_int_t ngx_stream_lua_shared_memory_init(ngx_shm_zone_t *shm_zone,


### PR DESCRIPTION
As the req_type in stream subsystem is unexported.
Fix https://github.com/openresty/stream-lua-nginx-module/issues/180.