### PR TITLE
bugfix: ignore the `raw` argument when acquiring UDP request socket.

### DIFF
--- a/src/ngx_stream_lua_socket_udp.c
+++ b/src/ngx_stream_lua_socket_udp.c
@@ -1678,6 +1678,7 @@ ngx_stream_lua_udp_socket_cleanup(void *data)
 int
 ngx_stream_lua_req_socket_udp(lua_State *L)
 {
+    int                                             n;
     ngx_stream_lua_udp_connection_t                *pc;
     ngx_stream_lua_srv_conf_t                      *lscf;
     ngx_connection_t                               *c;
@@ -1688,6 +1689,17 @@ ngx_stream_lua_req_socket_udp(lua_State *L)
     ngx_stream_lua_co_ctx_t                        *coctx;
 
     ngx_stream_lua_socket_udp_upstream_t           *u;
+
+    n = lua_gettop(L);
+
+    if (n != 0 && n != 1) {
+        return luaL_error(L, "expecting zero arguments, but got %d",
+                          lua_gettop(L));
+    }
+
+    if (n == 1) {
+        lua_pop(L, 1);
+    }
 
     r = ngx_stream_lua_get_req(L);
 

--- a/t/142-req-udp-socket.t
+++ b/t/142-req-udp-socket.t
@@ -211,3 +211,35 @@ got the request socket
 --- grep_error_log_out
 stream lua finalize socket
 GC cycle done
+
+
+
+=== TEST 6: ngx.req.socket with raw argument, argument is ignored
+--- dgram_server_config
+    content_by_lua_block {
+        local sock, err = ngx.req.socket(true)
+        if not sock then
+            ngx.log(ngx.ERR, "failed to get the request socket: ", err)
+            return ngx.exit(ngx.ERROR)
+        end
+
+        local data, err = sock:receive()
+        if not data then
+            ngx.log(ngx.ERR, "failed to receive: ", err)
+            return ngx.exit(ngx.ERROR)
+        end
+
+        -- print("data: ", data)
+
+        local ok, err = sock:send("received: " .. data)
+        if not ok then
+            ngx.log(ngx.ERR, "failed to send: ", err)
+            return ngx.exit(ngx.ERROR)
+        end
+    }
+--- dgram_request chomp
+hello world! my
+--- dgram_response chomp
+received: hello world! my
+--- no_error_log
+[error]


### PR DESCRIPTION
sync with meta-lua-nginx-module e1f1f20.

https://github.com/openresty/meta-lua-nginx-module/pull/82