### PR TITLE
bugfix: memory leak in debug log function

### DIFF
--- a/src/ngx_stream_lua_logby.c
+++ b/src/ngx_stream_lua_logby.c
@@ -77,6 +77,9 @@ ngx_stream_lua_log_handler(ngx_stream_session_t *r)
 #if (NGX_STREAM_LUA_HAVE_MALLOC_TRIM)
     ngx_uint_t                           trim_cycle, trim_nreq;
     ngx_stream_lua_main_conf_t          *lmcf;
+#if (NGX_DEBUG)
+    ngx_int_t                            trim_ret;
+#endif
 #endif
     ngx_stream_lua_loc_conf_t           *llcf;
     ngx_stream_lua_ctx_t                *ctx;
@@ -96,8 +99,9 @@ ngx_stream_lua_log_handler(ngx_stream_session_t *r)
             lmcf->malloc_trim_req_count = 0;
 
 #if (NGX_DEBUG)
+            trim_ret = malloc_trim(1);
             ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
-                           "malloc_trim(1) returned %d", malloc_trim(1));
+                           "malloc_trim(1) returned %d", trim_ret);
 #else
             (void) malloc_trim(1);
 #endif


### PR DESCRIPTION
If turn on nginx debug log `./configure --with-debug ...`, but not select `debug_http` log level. 
ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ...) will be ignored, malloc_trim() can't be executed as function parameter.
And memory isn't returned to OS immediately. This bug may cause serious memory leak, OOM.
![截屏2020-12-03 下午5 52 27](https://user-images.githubusercontent.com/10736359/100993988-0bd57280-3591-11eb-8fae-00ee3500bd3f.png)
Simply,  `ngx_log_debug1` is optional, but `malloc_trim` obligatory. 