### PR TITLE
chore: fix possible null pointer dereference found by Coverity

### DIFF
--- a/src/ngx_stream_lua_timer.c
+++ b/src/ngx_stream_lua_timer.c
@@ -784,16 +784,19 @@ ngx_stream_lua_log_timer_error(ngx_log_t *log, u_char *buf, size_t len)
     len -= p - buf;
     buf = p;
 
-    if (c->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
-        len -= p - buf;
-        buf = p;
-    }
+    if (c != NULL) {
+        if (c->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
+            len -= p - buf;
+            buf = p;
+        }
 
-    if (c && c->listening && c->listening->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
-        /* len -= p - buf; */
-        buf = p;
+        if (c->listening && c->listening->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", server: %V", 
+                             &c->listening->addr_text);
+            /* len -= p - buf; */
+            buf = p;
+        }
     }
 
     return buf;


### PR DESCRIPTION
```
785    buf = p;
786
   deref_ptr: Directly dereferencing pointer c.
787    if (c->addr_text.len) {
788        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
789        len -= p - buf;
790        buf = p;
791    }
792
   CID 251610 (#1 of 1): Dereference before null check (REVERSE_INULL)check_after_deref: Null-checking c suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
793    if (c && c->listening && c->listening->addr_text.len) {
794        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
795        /* len -= p - buf; */
796        buf = p;
797    }
```