### PR TITLE
src/ngx_stream_lua_ssl_certby.c: fix possible null pointer dereference found by Coverity

### DIFF
--- a/src/ngx_stream_lua_ssl_certby.c
+++ b/src/ngx_stream_lua_ssl_certby.c
@@ -440,16 +440,19 @@ ngx_stream_lua_log_ssl_cert_error(ngx_log_t *log, u_char *buf, size_t len)
 
     c = log->data;
 
-    if (c->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
-        len -= p - buf;
-        buf = p;
-    }
+    if (c != NULL) {
+        if (c->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
+            len -= p - buf;
+            buf = p;
+        }
 
-    if (c && c->listening && c->listening->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
-        /* len -= p - buf; */
-        buf = p;
+        if (c->listening && c->listening->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", server: %V", 
+                             &c->listening->addr_text);
+            /* len -= p - buf; */
+            buf = p;
+        }
     }
 
     return buf;


### PR DESCRIPTION
```

441    c = log->data;
442
   deref_ptr: Directly dereferencing pointer c.
443    if (c->addr_text.len) {
444        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
445        len -= p - buf;
446        buf = p;
447    }
448
   CID 251599 (#1 of 1): Dereference before null check (REVERSE_INULL)check_after_deref: Null-checking c suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
449    if (c && c->listening && c->listening->addr_text.len) {
450        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
451        /* len -= p - buf; */
452        buf = p;
453    }
```