### PR TITLE
change: changed from graceful shutdown to abort when lua_resume return LUA_ERRMEM.

### DIFF
--- a/src/ngx_stream_lua_util.c
+++ b/src/ngx_stream_lua_util.c
@@ -1132,7 +1132,7 @@ user_co_done:
                 break;
 
             case LUA_ERRMEM:
-                err = "memory allocation error when running lua coroutine";
+                err = "[lua] memory allocation error";
                 ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0, err);
                 abort();
                 break;

--- a/src/ngx_stream_lua_util.c
+++ b/src/ngx_stream_lua_util.c
@@ -1132,8 +1132,9 @@ user_co_done:
                 break;
 
             case LUA_ERRMEM:
-                err = "memory allocation error";
-                ngx_quit = 1;
+                err = "memory allocation error when running lua coroutine";
+                ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0, err);
+                abort();
                 break;
 
             case LUA_ERRERR:


### PR DESCRIPTION


If the worker voluntary enter into graceful shutdown state, the master will not respawn worker with the same worker id until the worker exit.
when reuseport is on, the new connections assigned to the voluntary graceful shutdown worker will not be accepted.
when reuseport is off, the new connections will be accepted by other processes which are still working. But if all workers are in voluntary shutdown state, the new connections will not be accepted.

So the worker should not enter into the voluntary graceful shutdown state when LUA_ERRMEM occurs.