### PR TITLE
bugfix: old coroutine APIs were used in the preread and ssl_cert phase

### DIFF
--- a/src/ngx_stream_lua_coroutine.c
+++ b/src/ngx_stream_lua_coroutine.c
@@ -368,10 +368,7 @@ ngx_stream_lua_inject_coroutine_api(ngx_log_t *log, lua_State *L)
 #else
                         "local ctx = raw_ctx(r)\n"
 #endif
-                        /* ignore header and body filters */
-                        "if ctx ~= 0x020 and ctx ~= 0x040 then\n"
-                            "return ours(...)\n"
-                        "end\n"
+                        "return ours(...)\n"
                     "end\n"
                     "return std(...)\n"
                 "end\n"

--- a/t/139-ssl-cert-by.t
+++ b/t/139-ssl-cert-by.t
@@ -1057,7 +1057,7 @@ close: 1 nil
 [alert]
 --- grep_error_log eval: qr/uthread: [^.,]+/
 --- grep_error_log_out
-uthread: thread created: suspended
+uthread: thread created: running
 uthread: hello in thread
 uthread: done
 


### PR DESCRIPTION
calling coroutine APIs in the preread and ssl_cert phase will return abnormal results