### PR TITLE
feature: add lua_ssl_ciphersuites directive for specifying the enabled TLSv1.3 ciphersuites

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ behavior.
 * [lua_socket_keepalive_timeout](https://github.com/openresty/lua-nginx-module#lua_socket_keepalive_timeout)
 * [lua_socket_log_errors](https://github.com/openresty/lua-nginx-module#lua_socket_log_errors)
 * [lua_ssl_ciphers](https://github.com/openresty/lua-nginx-module#lua_ssl_ciphers)
+* [lua_ssl_ciphersuites](https://github.com/openresty/lua-nginx-module#lua_ssl_ciphersuites)
 * [lua_ssl_crl](https://github.com/openresty/lua-nginx-module#lua_ssl_crl)
 * [lua_ssl_protocols](https://github.com/openresty/lua-nginx-module#lua_ssl_protocols)
 * [lua_ssl_trusted_certificate](https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate)

--- a/src/ngx_stream_lua_common.h
+++ b/src/ngx_stream_lua_common.h
@@ -246,6 +246,7 @@ struct ngx_stream_lua_srv_conf_s {
     ngx_ssl_t              *ssl;  /* shared by SSL cosockets */
     ngx_uint_t              ssl_protocols;
     ngx_str_t               ssl_ciphers;
+    ngx_str_t               ssl_ciphersuites;
     ngx_uint_t              ssl_verify_depth;
     ngx_str_t               ssl_trusted_certificate;
     ngx_str_t               ssl_crl;

--- a/src/ngx_stream_lua_common.h
+++ b/src/ngx_stream_lua_common.h
@@ -246,7 +246,9 @@ struct ngx_stream_lua_srv_conf_s {
     ngx_ssl_t              *ssl;  /* shared by SSL cosockets */
     ngx_uint_t              ssl_protocols;
     ngx_str_t               ssl_ciphers;
+#ifdef NGX_SSL_TLSv1_3
     ngx_str_t               ssl_ciphersuites;
+#endif
     ngx_uint_t              ssl_verify_depth;
     ngx_str_t               ssl_trusted_certificate;
     ngx_str_t               ssl_crl;

--- a/src/ngx_stream_lua_module.c
+++ b/src/ngx_stream_lua_module.c
@@ -856,10 +856,12 @@ ngx_stream_lua_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
                              "DEFAULT");
 
 #ifdef NGX_SSL_TLSv1_3
-    ngx_conf_merge_str_value(conf->ssl_ciphersuites, prev->ssl_ciphersuites,
-                             "TLS_AES_256_GCM_SHA384"
-                             ":TLS_CHACHA20_POLY1305_SHA256"
-                             ":TLS_AES_128_GCM_SHA256");
+    if (conf->ssl_ciphersuites.data == NULL) {
+        if (prev->ssl_ciphersuites.data) {
+            conf->ssl_ciphersuites.len = prev->ssl_ciphersuites.len;
+            conf->ssl_ciphersuites.data = prev->ssl_ciphersuites.data;
+        }
+    }
 #endif
 
     ngx_conf_merge_uint_value(conf->ssl_verify_depth,
@@ -952,21 +954,25 @@ ngx_stream_lua_set_ssl(ngx_conf_t *cf, ngx_stream_lua_srv_conf_t *lscf)
 #ifdef NGX_SSL_TLSv1_3
 #   if OPENSSL_VERSION_NUMBER >= 0x1010100fL
 
-    if (SSL_CTX_set_ciphersuites(lscf->ssl->ctx,
-                                (const char *) lscf->ssl_ciphersuites.data)
-        == 0)
-    {
-        ngx_ssl_error(NGX_LOG_EMERG, cf->log, 0,
-                      "SSL_CTX_set_ciphersuites(\"%V\") failed",
-                      &lscf->ssl_ciphersuites);
-        return NGX_ERROR;
+    if (lscf->ssl_ciphersuites.data) {
+        if (SSL_CTX_set_ciphersuites(lscf->ssl->ctx,
+                                    (const char *) lscf->ssl_ciphersuites.data)
+            == 0)
+        {
+            ngx_ssl_error(NGX_LOG_EMERG, cf->log, 0,
+                          "SSL_CTX_set_ciphersuites(\"%V\") failed",
+                          &lscf->ssl_ciphersuites);
+            return NGX_ERROR;
+        }
     }
 
 #   else
 
-    ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                  "OpenSSL too old to support lua_ssl_ciphersuites");
-    return NGX_ERROR;
+    if (lscf->ssl_ciphersuites.data) {
+        ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                      "OpenSSL too old to support lua_ssl_ciphersuites");
+        return NGX_ERROR;
+    }
 
 #   endif
 #endif

--- a/src/ngx_stream_lua_module.c
+++ b/src/ngx_stream_lua_module.c
@@ -966,7 +966,7 @@ ngx_stream_lua_set_ssl(ngx_conf_t *cf, ngx_stream_lua_srv_conf_t *lscf)
 
     ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                   "OpenSSL too old to support lua_ssl_ciphersuites");
-    return NGX_CONF_ERROR;
+    return NGX_ERROR;
 
 #   endif
 #endif

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -2491,6 +2491,7 @@ SSL reused session
 
 
 === TEST 32: default cipher - TLSv1.3
+--- skip_openssl: 8: < 1.1.1
 --- http_config
     server {
         listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -2577,6 +2578,7 @@ SSL reused session
 
 
 === TEST 33: explicit cipher configuration - TLSv1.3
+--- skip_openssl: 8: < 1.1.1
 --- http_config
     server {
         listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -2664,6 +2666,7 @@ SSL reused session
 
 
 === TEST 34: explicit cipher configuration not in the default list - TLSv1.3
+--- skip_openssl: 8: < 1.1.1
 --- http_config
     server {
         listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -6,7 +6,7 @@ use File::Basename;
 
 repeat_each(2);
 
-plan tests => repeat_each() * 216;
+plan tests => repeat_each() * 240;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
@@ -2486,4 +2486,260 @@ lua ssl certificate verify error: (18: self signed certificate)
 --- no_error_log
 SSL reused session
 [alert]
+--- timeout: 5
+
+
+
+=== TEST 32: default cipher - TLSv1.3
+--- http_config
+    server {
+        listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name         test.com;
+        ssl_certificate     $TEST_NGINX_CERT_DIR/cert/test.crt;
+        ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_protocols       TLSv1.3;
+
+        location / {
+            content_by_lua_block {
+                ngx.exit(200)
+            }
+        }
+    }
+--- stream_server_config
+    lua_ssl_protocols TLSv1.3;
+
+    content_by_lua_block {
+        local sock = ngx.socket.tcp()
+        sock:settimeout(2000)
+
+        do
+            local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local session, err = sock:sslhandshake(nil, "test.com")
+            if not session then
+                ngx.say("failed to do SSL handshake: ", err)
+                return
+            end
+
+            ngx.say("ssl handshake: ", type(session))
+
+            local req = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send stream request: ", err)
+                return
+            end
+
+            ngx.say("sent stream request: ", bytes, " bytes.")
+
+            local line, err = sock:receive()
+            if not line then
+                ngx.say("failed to recieve response status line: ", err)
+                return
+            end
+
+            ngx.say("received: ", line)
+
+            local ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        end  -- do
+        collectgarbage()
+    }
+
+--- stream_response
+connected: 1
+ssl handshake: userdata
+sent stream request: 53 bytes.
+received: HTTP/1.1 200 OK
+close: 1 nil
+
+--- log_level: debug
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
+--- grep_error_log_out eval
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
+$/
+--- error_log eval
+['lua ssl server name: "test.com"',
+qr/SSL: TLSv1.3, cipher: "TLS_AES_256_GCM_SHA384 TLSv1.3/]
+--- no_error_log
+SSL reused session
+[error]
+[alert]
+--- timeout: 10
+
+
+
+=== TEST 33: explicit cipher configuration - TLSv1.3
+--- http_config
+    server {
+        listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name         test.com;
+        ssl_certificate     $TEST_NGINX_CERT_DIR/cert/test.crt;
+        ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_protocols       TLSv1.3;
+
+        location / {
+            content_by_lua_block {
+                ngx.exit(200)
+            }
+        }
+    }
+--- stream_server_config
+    lua_ssl_protocols TLSv1.3;
+    lua_ssl_ciphersuites TLS_AES_128_GCM_SHA256;
+
+    content_by_lua_block {
+        local sock = ngx.socket.tcp()
+        sock:settimeout(2000)
+
+        do
+            local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local session, err = sock:sslhandshake(nil, "test.com")
+            if not session then
+                ngx.say("failed to do SSL handshake: ", err)
+                return
+            end
+
+            ngx.say("ssl handshake: ", type(session))
+
+            local req = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send stream request: ", err)
+                return
+            end
+
+            ngx.say("sent stream request: ", bytes, " bytes.")
+
+            local line, err = sock:receive()
+            if not line then
+                ngx.say("failed to recieve response status line: ", err)
+                return
+            end
+
+            ngx.say("received: ", line)
+
+            local ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        end  -- do
+        collectgarbage()
+    }
+
+--- stream_response
+connected: 1
+ssl handshake: userdata
+sent stream request: 53 bytes.
+received: HTTP/1.1 200 OK
+close: 1 nil
+
+--- log_level: debug
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
+--- grep_error_log_out eval
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
+$/
+--- error_log eval
+['lua ssl server name: "test.com"',
+qr/SSL: TLSv1.3, cipher: "TLS_AES_128_GCM_SHA256 TLSv1.3/]
+--- no_error_log
+SSL reused session
+[error]
+[alert]
+--- timeout: 10
+
+
+
+=== TEST 34: explicit cipher configuration not in the default list - TLSv1.3
+--- http_config
+    server {
+        listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name         test.com;
+        ssl_certificate     $TEST_NGINX_CERT_DIR/cert/test.crt;
+        ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_protocols       TLSv1.3;
+
+        location / {
+            content_by_lua_block {
+                ngx.exit(200)
+            }
+        }
+    }
+--- stream_server_config
+    lua_ssl_protocols TLSv1.3;
+    lua_ssl_ciphersuites TLS_AES_128_CCM_SHA256;
+
+    content_by_lua_block {
+        local sock = ngx.socket.tcp()
+        sock:settimeout(2000)
+
+        do
+            local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local session, err = sock:sslhandshake(nil, "test.com")
+            if not session then
+                ngx.say("failed to do SSL handshake: ", err)
+                return
+            end
+
+            ngx.say("ssl handshake: ", type(session))
+
+            local req = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send stream request: ", err)
+                return
+            end
+
+            ngx.say("sent stream request: ", bytes, " bytes.")
+
+            local line, err = sock:receive()
+            if not line then
+                ngx.say("failed to recieve response status line: ", err)
+                return
+            end
+
+            ngx.say("received: ", line)
+
+            local ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        end  -- do
+        collectgarbage()
+    }
+
+--- stream_response
+connected: 1
+failed to do SSL handshake: handshake failed
+
+--- log_level: debug
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
+--- grep_error_log_out
+--- error_log eval
+[
+qr/\[info\] .*?SSL_do_handshake\(\) failed .*?no shared cipher/,
+'lua ssl server name: "test.com"',
+]
+--- no_error_log
+SSL reused session
+[alert]
+[emerg]
 --- timeout: 5


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this stream-lua-nginx-module project.

sister PR: [lua-nginx-module #1889](https://github.com/openresty/lua-nginx-module/pull/1889)


this PR has substituted by #252 