### PR TITLE
bugfix: we didn't exclude the ssl_verify_callback when compiling with LibreSSL

### DIFF
--- a/src/ngx_stream_lua_ssl_certby.c
+++ b/src/ngx_stream_lua_ssl_certby.c
@@ -1352,6 +1352,7 @@ failed:
 }
 
 
+#ifndef LIBRESSL_VERSION_NUMBER
 static int
 ngx_stream_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
 {
@@ -1363,6 +1364,7 @@ ngx_stream_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
      */
     return 1;
 }
+#endif
 
 
 int


### PR DESCRIPTION
It leads to 'error: ‘ngx_stream_lua_ssl_verify_callback’ defined but not used [-Werror=unused-function]'
error.