### PR TITLE
bugfix: we should ignore match limit in DFA mode.

### DIFF
--- a/src/ngx_stream_lua_regex.c
+++ b/src/ngx_stream_lua_regex.c
@@ -321,7 +321,10 @@ ngx_stream_lua_ffi_compile_regex(const unsigned char *pat, size_t pat_len,
 
 #endif /* LUA_HAVE_PCRE_JIT */
 
-    if (sd && lmcf && lmcf->regex_match_limit > 0) {
+    if (sd
+        && lmcf && lmcf->regex_match_limit > 0
+        && !(flags & NGX_LUA_RE_MODE_DFA))
+    {
         sd->flags |= PCRE_EXTRA_MATCH_LIMIT;
         sd->match_limit = lmcf->regex_match_limit;
     }

--- a/t/120-re-find.t
+++ b/t/120-re-find.t
@@ -768,3 +768,31 @@ not matched!
 not matched!
 --- no_error_log
 [error]
+
+
+
+=== TEST 31: ignore match limit in DFA mode
+--- stream_config
+    lua_regex_match_limit 1;
+--- stream_server_config
+    content_by_lua_block {
+        local s = "This is <something> <something else> <something further> no more"
+        local from, to, err = ngx.re.find(s, "<.*>", "d")
+        if from then
+            ngx.say("from: ", from)
+            ngx.say("to: ", to)
+            ngx.say("matched: ", string.sub(s, from, to))
+        else
+            if err then
+                ngx.say("error: ", err)
+                return
+            end
+            ngx.say("not matched!")
+        end
+    }
+--- stream_response
+from: 9
+to: 56
+matched: <something> <something else> <something further>
+--- no_error_log
+[error]


### PR DESCRIPTION
lua_regex_match_limit takes effect globally for all regexes used in ngx.re
api. However, the match_limit field of pcre_extra block is not supported in
pcre_dfa_exec()(so does match_limit_recursion), because it is meaningless
in DFA matching. And pcre_dfa_exec() will return -18(PCRE_ERROR_DFA_UMLIMIT)
when the directive is used. Here we just ignore the directive in DFA mode.