### PR TITLE
feature: Support lua_ssl_certificate and lua_ssl_certificate_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ behavior.
 * [lua_ssl_ciphers](https://github.com/openresty/lua-nginx-module#lua_ssl_ciphers)
 * [lua_ssl_crl](https://github.com/openresty/lua-nginx-module#lua_ssl_crl)
 * [lua_ssl_protocols](https://github.com/openresty/lua-nginx-module#lua_ssl_protocols)
+* [lua_ssl_certificate](https://github.com/openresty/lua-nginx-module#lua_ssl_certificate)
+* [lua_ssl_certificate_key](https://github.com/openresty/lua-nginx-module#lua_ssl_certificate_key)
 * [lua_ssl_trusted_certificate](https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate)
 * [lua_ssl_verify_depth](https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth)
 * [lua_ssl_conf_command](https://github.com/openresty/lua-nginx-module#lua_ssl_conf_command)

--- a/src/ngx_stream_lua_common.h
+++ b/src/ngx_stream_lua_common.h
@@ -245,6 +245,8 @@ struct ngx_stream_lua_main_conf_s {
 struct ngx_stream_lua_srv_conf_s {
 #if (NGX_STREAM_SSL)
     ngx_ssl_t              *ssl;  /* shared by SSL cosockets */
+    ngx_array_t            *ssl_certificates;
+    ngx_array_t            *ssl_certificate_keys;
     ngx_uint_t              ssl_protocols;
     ngx_str_t               ssl_ciphers;
     ngx_uint_t              ssl_verify_depth;

--- a/src/ngx_stream_lua_module.c
+++ b/src/ngx_stream_lua_module.c
@@ -422,6 +422,20 @@ static ngx_command_t ngx_stream_lua_cmds[] = {
       offsetof(ngx_stream_lua_srv_conf_t, ssl_verify_depth),
       NULL },
 
+    { ngx_string("lua_ssl_certificate"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_array_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_lua_srv_conf_t, ssl_certificates),
+      NULL },
+
+    { ngx_string("lua_ssl_certificate_key"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_array_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_lua_srv_conf_t, ssl_certificate_keys),
+      NULL },
+
     { ngx_string("lua_ssl_trusted_certificate"),
       NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_str_slot,
@@ -814,6 +828,8 @@ ngx_stream_lua_create_srv_conf(ngx_conf_t *cf)
 
 #if (NGX_STREAM_SSL)
     conf->ssl_verify_depth = NGX_CONF_UNSET_UINT;
+    conf->ssl_certificates = NGX_CONF_UNSET_PTR;
+    conf->ssl_certificate_keys = NGX_CONF_UNSET_PTR;
 #endif
 
     return conf;
@@ -926,6 +942,10 @@ ngx_stream_lua_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_uint_value(conf->ssl_verify_depth,
                               prev->ssl_verify_depth, 1);
+    ngx_conf_merge_ptr_value(conf->ssl_certificates,
+                             prev->ssl_certificates, NULL);
+    ngx_conf_merge_ptr_value(conf->ssl_certificate_keys,
+                             prev->ssl_certificate_keys, NULL);
     ngx_conf_merge_str_value(conf->ssl_trusted_certificate,
                              prev->ssl_trusted_certificate, "");
     ngx_conf_merge_str_value(conf->ssl_crl, prev->ssl_crl, "");
@@ -993,6 +1013,20 @@ ngx_stream_lua_set_ssl(ngx_conf_t *cf, ngx_stream_lua_srv_conf_t *lscf)
 
     lscf->ssl->log = cf->log;
 
+    if (lscf->ssl_certificates) {
+        if (lscf->ssl_certificate_keys == NULL
+            || lscf->ssl_certificate_keys->nelts
+            < lscf->ssl_certificates->nelts)
+        {
+            ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                          "no \"lua_ssl_certificate_key\" is defined "
+                          "for certificate \"%V\"",
+                          ((ngx_str_t *) lscf->ssl_certificates->elts)
+                          + lscf->ssl_certificates->nelts - 1);
+            return NGX_ERROR;
+        }
+    }
+
     if (ngx_ssl_create(lscf->ssl, lscf->ssl_protocols, NULL) != NGX_OK) {
         return NGX_ERROR;
     }
@@ -1012,6 +1046,16 @@ ngx_stream_lua_set_ssl(ngx_conf_t *cf, ngx_stream_lua_srv_conf_t *lscf)
         ngx_ssl_error(NGX_LOG_EMERG, cf->log, 0,
                       "SSL_CTX_set_cipher_list(\"%V\") failed",
                       &lscf->ssl_ciphers);
+        return NGX_ERROR;
+    }
+
+    if (lscf->ssl_certificates
+        && ngx_ssl_certificates(cf, lscf->ssl,
+                                lscf->ssl_certificates,
+                                lscf->ssl_certificate_keys,
+                                NULL)
+        != NGX_OK)
+    {
         return NGX_ERROR;
     }
 

--- a/t/163-ssl-two-verification.t
+++ b/t/163-ssl-two-verification.t
@@ -11,7 +11,7 @@ my $openssl_version = eval { `$NginxBinary -V 2>&1` };
 if ($openssl_version =~ m/built with OpenSSL (0\S*|1\.0\S*|1\.1\.0\S*)/) {
     plan(skip_all => "too old OpenSSL, need 1.1.1, was $1");
 } else {
-    plan tests => repeat_each() * (blocks() * 7);
+    plan tests => repeat_each() * (blocks() * 6);
 }
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();

--- a/t/163-ssl-two-verification.t
+++ b/t/163-ssl-two-verification.t
@@ -1,0 +1,113 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua::Stream;
+
+repeat_each(3);
+
+# All these tests need to have new openssl
+my $NginxBinary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+my $openssl_version = eval { `$NginxBinary -V 2>&1` };
+
+if ($openssl_version =~ m/built with OpenSSL (0\S*|1\.0\S*|1\.1\.0\S*)/) {
+    plan(skip_all => "too old OpenSSL, need 1.1.1, was $1");
+} else {
+    plan tests => repeat_each() * (blocks() * 7);
+}
+
+$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
+
+#log_level 'warn';
+log_level 'debug';
+
+no_long_string();
+#no_diff();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: simple logging
+--- stream_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        #listen 127.0.0.1:4433 ssl;
+        ssl_client_hello_by_lua_block { print("ssl client hello by lua is running!") }
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+        #ssl_trusted_certificate ../../cert/test.crt;
+        ssl_client_certificate ../../cert/test.crt;
+        ssl_verify_client on;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+        return 'it works!\n';
+    }
+--- stream_server_config
+    lua_ssl_certificate ../../cert/test.crt;
+    lua_ssl_certificate_key ../../cert/test.key;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    content_by_lua_block {
+        do
+            local sock = ngx.socket.tcp()
+
+            sock:settimeout(2000)
+
+            local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            -- local ok, err = sock:connect("127.0.0.1", 4433)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local sess, err = sock:sslhandshake(nil, "test.com", true)
+            if not sess then
+                ngx.say("failed to do SSL handshake: ", err)
+                return
+            end
+
+            ngx.say("ssl handshake: ", type(sess))
+
+            while true do
+                local line, err = sock:receive()
+                if not line then
+                    -- ngx.say("failed to receive response status line: ", err)
+                    break
+                end
+
+                ngx.say("received: ", line)
+            end
+
+            local ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        end  -- do
+        -- collectgarbage()
+    }
+
+--- stream_response
+connected: 1
+ssl handshake: userdata
+received: it works!
+close: 1 nil
+
+--- error_log
+lua ssl server name: "test.com"
+
+--- no_error_log
+[error]
+[alert]
+--- grep_error_log eval: qr/ssl_client_hello_by_lua:.*?,|\bssl client hello: connection reusable: \d+|\breusable connection: \d+/
+--- grep_error_log_out eval
+qr/reusable connection: 1
+reusable connection: 0
+ssl client hello: connection reusable: 0
+reusable connection: 0
+ssl_client_hello_by_lua:1: ssl client hello by lua is running!,
+reusable connection: 0
+reusable connection: 0
+reusable connection: 0
+reusable connection: 0
+reusable connection: 0
+/


### PR DESCRIPTION
Support lua_ssl_certificate and lua_ssl_certificate_key，these 2 directives are used for ssl two-way verification