### PR TITLE
optimize: now we make use of the new lua_getexdata2 and lua_setexdata…

### DIFF
--- a/src/ngx_stream_lua_contentby.c
+++ b/src/ngx_stream_lua_contentby.c
@@ -80,6 +80,8 @@ ngx_stream_lua_content_by_chunk(lua_State *L, ngx_stream_lua_request_t *r)
     ctx->cur_co_ctx->co_top = 1;
 #endif
 
+    ngx_stream_lua_attach_co_ctx_to_L(co, ctx->cur_co_ctx);
+
     /*  {{{ register request cleanup hooks */
     if (ctx->cleanup == NULL) {
         cln = ngx_stream_lua_cleanup_add(r, 0);

--- a/src/ngx_stream_lua_coroutine.c
+++ b/src/ngx_stream_lua_coroutine.c
@@ -152,6 +152,7 @@ ngx_stream_lua_coroutine_create_helper(lua_State *L,
 
 #ifdef OPENRESTY_LUAJIT
     ngx_stream_lua_set_req(co, r);
+    ngx_stream_lua_attach_co_ctx_to_L(co, coctx);
 #else
     /* make new coroutine share globals of the parent coroutine.
      * NOTE: globals don't have to be separated! */

--- a/src/ngx_stream_lua_module.c
+++ b/src/ngx_stream_lua_module.c
@@ -593,6 +593,15 @@ ngx_stream_lua_init(ngx_conf_t *cf)
                           "the OpenResty releases from https://openresty.org/"
                           "en/download.html)");
         }
+#else
+#   if !defined(HAVE_LUA_EXDATA2)
+        ngx_log_error(NGX_LOG_ALERT, cf->log, 0,
+                      "detected an old version of OpenResty's LuaJIT missing "
+                      "the exdata2 API and thus the "
+                      "performance will be compromised; please upgrade to the "
+                      "latest version of OpenResty's LuaJIT: "
+                      "https://github.com/openresty/luajit2");
+#   endif
 #endif
 
 

--- a/src/ngx_stream_lua_prereadby.c
+++ b/src/ngx_stream_lua_prereadby.c
@@ -247,6 +247,8 @@ ngx_stream_lua_preread_by_chunk(lua_State *L, ngx_stream_lua_request_t *r)
     ctx->cur_co_ctx->co_top = 1;
 #endif
 
+    ngx_stream_lua_attach_co_ctx_to_L(co, ctx->cur_co_ctx);
+
     /*  }}} */
 
     /*  {{{ register request cleanup hooks */

--- a/src/ngx_stream_lua_ssl_certby.c
+++ b/src/ngx_stream_lua_ssl_certby.c
@@ -517,6 +517,8 @@ ngx_stream_lua_ssl_cert_by_chunk(lua_State *L, ngx_stream_lua_request_t *r)
     ctx->cur_co_ctx->co_top = 1;
 #endif
 
+    ngx_stream_lua_attach_co_ctx_to_L(co, ctx->cur_co_ctx);
+
     /* register request cleanup hooks */
     if (ctx->cleanup == NULL) {
         cln = ngx_stream_lua_cleanup_add(r, 0);

--- a/src/ngx_stream_lua_ssl_client_helloby.c
+++ b/src/ngx_stream_lua_ssl_client_helloby.c
@@ -503,6 +503,8 @@ ngx_stream_lua_ssl_client_hello_by_chunk(lua_State *L,
     ctx->cur_co_ctx->co_top = 1;
 #endif
 
+    ngx_stream_lua_attach_co_ctx_to_L(co, ctx->cur_co_ctx);
+
     /* register request cleanup hooks */
     if (ctx->cleanup == NULL) {
         cln = ngx_stream_lua_cleanup_add(r, 0);

--- a/src/ngx_stream_lua_timer.c
+++ b/src/ngx_stream_lua_timer.c
@@ -694,6 +694,8 @@ ngx_stream_lua_timer_handler(ngx_event_t *ev)
     /*  save the request in coroutine globals table */
     ngx_stream_lua_set_req(tctx.co, r);
 
+    ngx_stream_lua_attach_co_ctx_to_L(tctx.co, ctx->cur_co_ctx);
+
     lmcf->running_timers++;
 
     lua_pushboolean(tctx.co, tctx.premature);

--- a/src/ngx_stream_lua_uthread.c
+++ b/src/ngx_stream_lua_uthread.c
@@ -105,6 +105,8 @@ ngx_stream_lua_uthread_spawn(lua_State *L)
     coctx->parent_co_ctx = ctx->cur_co_ctx;
     ctx->cur_co_ctx = coctx;
 
+    ngx_stream_lua_attach_co_ctx_to_L(coctx->co, coctx);
+
     ngx_stream_lua_probe_user_thread_spawn(r, L, coctx->co);
 
     dd("yielding with arg %s, top=%d, index-1:%s", luaL_typename(L, -1),

--- a/src/ngx_stream_lua_util.c
+++ b/src/ngx_stream_lua_util.c
@@ -2590,6 +2590,9 @@ ngx_stream_lua_traceback(lua_State *L)
 ngx_stream_lua_co_ctx_t *
 ngx_stream_lua_get_co_ctx(lua_State *L, ngx_stream_lua_ctx_t *ctx)
 {
+#ifdef HAVE_LUA_EXDATA2
+    return (ngx_stream_lua_co_ctx_t *) lua_getexdata2(L);
+#else
     ngx_uint_t                   i;
     ngx_list_part_t             *part;
 
@@ -2626,6 +2629,7 @@ ngx_stream_lua_get_co_ctx(lua_State *L, ngx_stream_lua_ctx_t *ctx)
     }
 
     return NULL;
+#endif
 }
 
 

--- a/src/ngx_stream_lua_util.h
+++ b/src/ngx_stream_lua_util.h
@@ -191,6 +191,16 @@ ngx_int_t ngx_stream_lua_open_and_stat_file(u_char *name,
 ngx_chain_t *ngx_stream_lua_chain_get_free_buf(ngx_log_t *log, ngx_pool_t *p,
     ngx_chain_t **free, size_t len);
 
+
+static ngx_inline void
+ngx_stream_lua_attach_co_ctx_to_L(lua_State *L, ngx_stream_lua_co_ctx_t *coctx)
+{
+#ifdef HAVE_LUA_EXDATA2
+    lua_setexdata2(L, (void *) coctx);
+#endif
+}
+
+
 #ifndef OPENRESTY_LUAJIT
 void ngx_stream_lua_create_new_globals_table(lua_State *L, int narr, int nrec);
 #endif


### PR DESCRIPTION
…2 to attach coctx to the Lua thread objects directly which save the lookup overhead which can become the bottleneck when there are many Lua light threads around in a single request handler.