### PR TITLE
bugfix: don't include pcre.h with PCRE2 used

### DIFF
--- a/src/ngx_stream_lua_common.h
+++ b/src/ngx_stream_lua_common.h
@@ -35,7 +35,7 @@
 #include "ngx_stream_lua_request.h"
 
 
-#if (NGX_PCRE)
+#if defined(NGX_PCRE) && !defined(NGX_PCRE2)
 
 #include <pcre.h>
 


### PR DESCRIPTION
pcre.h is a PCRE header and is not exposed by PCRE2 library causing compilation error as the header is not found.

Don't include pcre.h if nginx is compiled with PCRE2 support enabled.

Fixes: 08841a243f1a ("feature: support pcre2")