### PR TITLE
bugfix: correctly error out when ngx.socket.tcp is shutdown before connect

### DIFF
--- a/t/058-tcp-socket.t
+++ b/t/058-tcp-socket.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua::Stream;
 
 repeat_each(2);
 
-plan tests => repeat_each() * 219;
+plan tests => repeat_each() * 221;
 
 our $HtmlDir = html_dir;
 
@@ -3526,3 +3526,22 @@ orld
 [error]
 --- error_log
 lua tcp socket calling receiveany() method to read at most 7 bytes
+
+
+
+=== TEST 67: shutdown on a not connected socket correctly throws error
+--- stream_server_config
+    lua_socket_connect_timeout 1s;
+    resolver $TEST_NGINX_RESOLVER ipv6=off;
+    resolver_timeout 3s;
+
+    content_by_lua_block {
+        local sock = ngx.socket.tcp()
+
+        local ok, err = sock:shutdown('send')
+        ngx.log(ngx.ERR, 'shutdown on a not connected socket: ', err)
+
+    }
+
+--- error_log
+shutdown on a not connected socket: closed


### PR DESCRIPTION
Can be reproduced by following example:
```
user www-data;
daemon off;
master_process off;

events {
}

stream {
	error_log /dev/stdout info;
	server {
		listen 23333;
		    content_by_lua_block {
                        local t = ngx.socket.tcp()
                        t:shutdown("send")
		    }
	}
}
```

This PR moves the check of `u` before calling `ngx_stream_lua_socket_handle_write_error`.