### PR TITLE
changes: remove the useless pcre config

### DIFF
--- a/config
+++ b/config
@@ -405,45 +405,6 @@ fi
 
 # ----------------------------------------
 
-if [ $USE_PCRE = YES -o $PCRE != NONE ] && [ $PCRE != NO -a $PCRE != YES ] && [ $PCRE2 != YES ]; then
-    # force pcre_version symbol to be required when PCRE is statically linked
-    case "$NGX_PLATFORM" in
-        Darwin:*)
-            ngx_feature="require defined symbols (-u)"
-            ngx_feature_name=
-            ngx_feature_path=
-            ngx_feature_libs="-Wl,-u,_strerror"
-            ngx_feature_run=no
-            ngx_feature_incs="#include <stdio.h>"
-            ngx_feature_test='printf("hello");'
-
-            . auto/feature
-
-            if [ $ngx_found = yes ]; then
-                CORE_LIBS="-Wl,-u,_pcre_version $CORE_LIBS"
-            fi
-        ;;
-
-        *)
-            ngx_feature="require defined symbols (--require-defined)"
-            ngx_feature_name=
-            ngx_feature_path=
-            ngx_feature_libs="-Wl,--require-defined=strerror"
-            ngx_feature_run=no
-            ngx_feature_incs="#include <stdio.h>"
-            ngx_feature_test='printf("hello");'
-
-            . auto/feature
-
-            if [ $ngx_found = yes ]; then
-                CORE_LIBS="-Wl,--require-defined=pcre_version $CORE_LIBS"
-            fi
-        ;;
-    esac
-fi
-
-# ----------------------------------------
-
 USE_MD5=YES
 USE_SHA1=YES
 


### PR DESCRIPTION
Since the C API ngx_stream_lua_pcre_version was introduced in this module, and Lua FFI no longer directly calls pcre_version, issue #168 is no longer necessary.
