### PR TITLE
feature: Add functions to parse DER formatted certificates/keys

### DIFF
--- a/src/ngx_stream_lua_ssl_certby.c
+++ b/src/ngx_stream_lua_ssl_certby.c
@@ -1186,6 +1186,76 @@ ngx_stream_lua_ffi_parse_pem_cert(const u_char *pem, size_t pem_len,
 }
 
 
+void *
+ngx_stream_lua_ffi_parse_der_cert(const char *data, size_t len,
+    char **err)
+{
+    BIO             *bio;
+    X509            *x509;
+    u_long           n;
+    STACK_OF(X509)  *chain;
+
+    bio = BIO_new_mem_buf((char *) data, len);
+    if (bio == NULL) {
+        *err = "BIO_new_mem_buf() failed";
+        ERR_clear_error();
+        return NULL;
+    }
+
+    x509 = d2i_X509_bio(bio, NULL);
+    if (x509 == NULL) {
+        *err = "d2i_X509_bio() failed";
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    chain = sk_X509_new_null();
+    if (chain == NULL) {
+        *err = "sk_X509_new_null() failed";
+        X509_free(x509);
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    if (sk_X509_push(chain, x509) == 0) {
+        *err = "sk_X509_push() failed";
+        sk_X509_free(chain);
+        X509_free(x509);
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    /* read rest of the chain */
+
+    while (!BIO_eof(bio)) {
+        x509 = d2i_X509_bio(bio, NULL);
+        if (x509 == NULL) {
+            *err = "d2i_X509_bio() failed in rest of chain";
+            sk_X509_pop_free(chain, X509_free);
+            BIO_free(bio);
+            ERR_clear_error();
+            return NULL;
+        }
+
+        if (sk_X509_push(chain, x509) == 0) {
+            *err = "sk_X509_push() failed in rest of chain";
+            sk_X509_pop_free(chain, X509_free);
+            X509_free(x509);
+            BIO_free(bio);
+            ERR_clear_error();
+            return NULL;
+        }
+    }
+
+    BIO_free(bio);
+
+    return chain;
+}
+
+
 void
 ngx_stream_lua_ffi_free_cert(void *cdata)
 {
@@ -1218,6 +1288,35 @@ ngx_stream_lua_ffi_parse_pem_priv_key(const u_char *pem, size_t pem_len,
     }
 
     BIO_free(in);
+
+    return pkey;
+}
+
+
+void *
+ngx_stream_lua_ffi_parse_der_priv_key(const char *data, size_t len,
+    char **err)
+{
+    BIO               *bio = NULL;
+    EVP_PKEY          *pkey = NULL;
+
+    bio = BIO_new_mem_buf((char *) data, len);
+    if (bio == NULL) {
+        *err = "BIO_new_mem_buf() failed";
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    pkey = d2i_PrivateKey_bio(bio, NULL);
+    if (pkey == NULL) {
+        *err = "d2i_PrivateKey_bio() failed";
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    BIO_free(bio);
 
     return pkey;
 }


### PR DESCRIPTION
This brings stream up to feature parity with HTTP

See https://github.com/openresty/lua-resty-core/pull/455 and https://github.com/openresty/lua-nginx-module/pull/2278