### PR TITLE
bugfix: fixed failure to build from source with nginx 1.25.5+

### DIFF
--- a/src/ngx_stream_lua_module.c
+++ b/src/ngx_stream_lua_module.c
@@ -864,12 +864,20 @@ ngx_stream_lua_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_stream_lua_srv_conf_t       *conf = child;
 
 #if (NGX_STREAM_SSL)
+#if defined(nginx_version) && nginx_version >= 1025005
+    ngx_stream_ssl_srv_conf_t       *sscf;
+#else
     ngx_stream_ssl_conf_t           *sscf;
+#endif
 
     dd("merge srv conf");
 
     sscf = ngx_stream_conf_get_module_srv_conf(cf, ngx_stream_ssl_module);
+#if defined(nginx_version) && nginx_version >= 1025005
+    if (sscf && sscf->ssl.ctx) {
+#else
     if (sscf && sscf->listen) {
+#endif
         if (conf->srv.ssl_client_hello_src.len == 0) {
             conf->srv.ssl_client_hello_src = prev->srv.ssl_client_hello_src;
             conf->srv.ssl_client_hello_src_key =

--- a/src/ngx_stream_lua_ssl_certby.c
+++ b/src/ngx_stream_lua_ssl_certby.c
@@ -1483,7 +1483,11 @@ ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
 
     ngx_stream_lua_ctx_t        *ctx;
     ngx_ssl_conn_t              *ssl_conn;
+#if defined(nginx_version) && nginx_version >= 1025005
+    ngx_stream_ssl_srv_conf_t   *sscf;
+#else
     ngx_stream_ssl_conf_t       *sscf;
+#endif
     STACK_OF(X509)              *chain = ca_certs;
     STACK_OF(X509_NAME)         *name_chain = NULL;
     X509                        *x509 = NULL;


### PR DESCRIPTION
Check for ssl context as in http lua module instead of a field removed in https://hg.nginx.org/nginx/rev/e28b044908cb.