### PR TITLE
feature: ngx_stream_lua_ffi_req_shared_ssl_ciphers()

### DIFF
--- a/src/ngx_stream_lua_ssl_certby.c
+++ b/src/ngx_stream_lua_ssl_certby.c
@@ -44,6 +44,7 @@ static u_char *ngx_stream_lua_log_ssl_cert_error(ngx_log_t *log, u_char *buf,
     size_t len);
 static ngx_int_t ngx_stream_lua_ssl_cert_by_chunk(lua_State *L,
     ngx_stream_lua_request_t *r);
+static int ngx_stream_lua_is_grease_cipher(uint16_t cipher_id);
 
 
 ngx_int_t
@@ -983,6 +984,80 @@ ngx_stream_lua_ffi_ssl_raw_client_addr(ngx_stream_lua_request_t *r, char **addr,
     }
 
     return NGX_OK;
+}
+
+
+static int
+ngx_stream_lua_is_grease_cipher(uint16_t cipher_id)
+{
+    /* GREASE values follow pattern: 0x?A?A where ? can be any hex digit */
+    /* and both ? must be the same */
+    /* Check if both bytes follow ?A pattern and high nibbles match */
+    return (cipher_id & 0x0F0F) == 0x0A0A;
+}
+
+
+int
+ngx_stream_lua_ffi_req_shared_ssl_ciphers(ngx_stream_lua_request_t *r,
+    uint16_t *ciphers, uint16_t *nciphers, int filter_grease, char **err)
+{
+#ifdef OPENSSL_IS_BORINGSSL
+
+    *err = "BoringSSL is not supported for SSL cipher operations";
+    return NGX_ERROR;
+
+#else
+    ngx_ssl_conn_t         *ssl_conn;
+    STACK_OF(SSL_CIPHER)   *sk, *ck;
+    int                     sn, cn, i, n;
+    uint16_t                cipher;
+
+    if (r == NULL || r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    sk = SSL_get1_supported_ciphers(ssl_conn);
+    ck = SSL_get_client_ciphers(ssl_conn);
+    sn = sk_SSL_CIPHER_num(sk);
+    cn = sk_SSL_CIPHER_num(ck);
+
+    if (sn > *nciphers) {
+        *err = "buffer too small";
+        *nciphers = 0;
+        sk_SSL_CIPHER_free(sk);
+        return NGX_ERROR;
+    }
+
+    for (*nciphers = 0, i = 0; i < sn; i++) {
+        cipher = SSL_CIPHER_get_protocol_id(sk_SSL_CIPHER_value(sk, i));
+
+        /* Skip GREASE ciphers if filtering is enabled */
+        if (filter_grease && ngx_stream_lua_is_grease_cipher(cipher)) {
+            continue;
+        }
+
+        for (n = 0; n < cn; n++) {
+            if (SSL_CIPHER_get_protocol_id(sk_SSL_CIPHER_value(ck, n))
+                == cipher)
+            {
+                ciphers[(*nciphers)++] = cipher;
+                break;
+            }
+        }
+    }
+
+    sk_SSL_CIPHER_free(sk);
+
+    return NGX_OK;
+#endif
+
 }
 
 


### PR DESCRIPTION
### Overview

This pull request introduces a new API to retrieve shared SSL ciphers between the client and server, with optional filtering for GREASE ciphers. It also includes corresponding tests to validate the functionality and error handling. The most important changes are grouped into two themes: **API Implementation** and **Testing Enhancements**.

### API Implementation:
* Added a new function `ngx_stream_lua_ffi_req_shared_ssl_ciphers` in `src/ngx_stream_lua_ssl_certby.c` to retrieve shared SSL ciphers, with an option to filter out GREASE ciphers. This function handles errors such as invalid requests, insufficient buffer size, and unsupported SSL libraries.
* Introduced a helper function `ngx_stream_lua_is_grease_cipher` to identify GREASE cipher IDs based on their pattern.


### Related  PR

Closed https://github.com/openresty/lua-resty-core/pull/505
Closed https://github.com/openresty/lua-nginx-module/pull/1962
Closed https://github.com/openresty/lua-nginx-module/pull/2424


### Testing Enhancements:
* Declared the new API function in the FFI interface in `t/140-ssl-c-api.t` to enable Lua integration.
* Added multiple test cases in `t/140-ssl-c-api.t` to validate:
  - Retrieval of supported ciphers without GREASE filtering.
  - Retrieval of supported ciphers with GREASE filtering.
  - Proper error handling when no SSL connection is present.