### PR TITLE
bugfix: parse_addr should use INADDR_ANY for "0.0.0.0", not INADDR_NONE

### DIFF
--- a/src/ngx_stream_lua_util.c
+++ b/src/ngx_stream_lua_util.c
@@ -3720,7 +3720,7 @@ ngx_stream_lua_parse_addr(lua_State *L, u_char *text, size_t len,
 #endif
 
     if (len == 7 && memcmp(text, "0.0.0.0", 7) == 0) {
-        inaddr = INADDR_NONE;
+        inaddr = INADDR_ANY;
         socklen = sizeof(struct sockaddr_in);
         family = AF_INET;
 

--- a/t/141-tcp-socket-bind.t
+++ b/t/141-tcp-socket-bind.t
@@ -224,3 +224,42 @@ server {
 127.0.0.1
 --- no_error_log
 [error]
+
+
+
+=== TEST 6: upstream sockets bind 0.0.0.0 (wildcard, regression for INADDR_NONE bug)
+--- stream_config
+server {
+   listen 127.0.1.2:2986;
+   content_by_lua_block {
+     ngx.say(ngx.var.remote_addr)
+   }
+}
+--- stream_server_config
+  content_by_lua_block {
+      local sock = ngx.socket.tcp()
+
+      local ok, err = sock:bind("0.0.0.0")
+      if not ok then
+          ngx.log(ngx.ERR, "bind failed: ", err)
+          return
+      end
+
+      local ok, err = sock:connect("127.0.1.2", 2986)
+      if not ok then
+          ngx.log(ngx.ERR, "connect failed: ", err)
+          return
+      end
+
+      local line, err, part = sock:receive()
+      if line then
+          ngx.say(line)
+      else
+          ngx.log(ngx.ERR, err)
+      end
+  }
+
+--- stream_response
+127.0.0.1
+--- no_error_log
+[error]

--- a/t/142-udp-socket-bind.t
+++ b/t/142-udp-socket-bind.t
@@ -272,3 +272,40 @@ server {
 
 --- no_error_log
 [error]
+
+
+
+=== TEST 6: upstream sockets bind 0.0.0.0 (wildcard, regression for INADDR_NONE bug)
+--- stream_config
+server {
+   listen 127.0.1.2:2986 udp;
+   content_by_lua_block {
+     ngx.log(ngx.INFO, "udp bind address: " .. ngx.var.remote_addr)
+   }
+}
+--- stream_server_config
+  content_by_lua_block {
+      local sock = ngx.socket.udp()
+
+      local ok, err = sock:bind("0.0.0.0")
+      if not ok then
+          ngx.log(ngx.ERR, "bind failed: ", err)
+          return
+      end
+
+      local ok, err = sock:setpeername("127.0.1.2", 2986)
+      if not ok then
+          ngx.log(ngx.ERR, "setpeername failed: ", err)
+          return
+      end
+
+      local ok, err = sock:send("trigger")
+      if not ok then
+          ngx.log(ngx.ERR, err)
+      end
+  }
+
+--- no_error_log
+[error]
+--- error_log
+udp bind address: 127.0.0.1


### PR DESCRIPTION
## Summary

The special-case for `"0.0.0.0"` in `ngx_stream_lua_parse_addr`, introduced in e50520b ("feature: add reuseport for binding local port for udp cosocket"), assigns `INADDR_NONE` (0xFFFFFFFF = 255.255.255.255) to `inaddr`. That value is later written into `sin->sin_addr.s_addr`, so the resulting sockaddr is the limited broadcast address rather than the wildcard.

As a result, `tcpsock:bind('0.0.0.0', ...)` and UDP cosocket binds that go through this path fail with `EADDRNOTAVAIL`.

```c
if (len == 7 && memcmp(text, "0.0.0.0", 7) == 0) {
-    inaddr = INADDR_NONE;
+    inaddr = INADDR_ANY;
    socklen = sizeof(struct sockaddr_in);
    family = AF_INET;
}
```

The intent of the special case was to bypass the fact that `ngx_inet_addr` returns `INADDR_NONE` both for parse failure and for the legitimate value `0.0.0.0`. The bypass is correct; only the constant used for the wildcard address was wrong. `INADDR_ANY` (0) is the right value.

## Test plan
- [ ] `tcpsock:bind('0.0.0.0', <port>)` succeeds and traffic uses the wildcard address
- [ ] UDP cosocket bind path with `0.0.0.0` succeeds
- [ ] Existing `prove -r t/` test suite passes