### PR TITLE
bugfix: add assert for ngx_stream_lua_get_req in ngx_stream_lua_sema_timeout_handler

### DIFF
--- a/src/ngx_stream_lua_semaphore.c
+++ b/src/ngx_stream_lua_semaphore.c
@@ -534,6 +534,7 @@ ngx_stream_lua_sema_timeout_handler(ngx_event_t *ev)
     sem->wait_count--;
 
     r = ngx_stream_lua_get_req(wait_co_ctx->co);
+    ngx_stream_lua_assert(r != NULL);
 
     ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
     ngx_stream_lua_assert(ctx != NULL);


### PR DESCRIPTION
DEREF_OF_NULL.RET.STAT Return value of a function 'ngx_stream_lua_get_req' is dereferenced at ngx_stream_lua_semaphore.c:537 without checking for NULL, but it is usually checked for this function (35/41).
 
Add assert for consistent of code.
 
Found by Linux Verification Center with Svace.
